### PR TITLE
Threshold-Based Icon Coloring & overlapping room entity sensor click fix! 🚛 👩‍🎨 

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ See the [Theming Guide](docs/THEMING.md) for detailed color configuration and cu
 - [x] **`Mold Indicator`**: animated warning indicator for mold detection with threshold-based display - thanks @ma-gu-16
 - [x] **`Entity Labels`**: display entity names under icons for better identification - thanks @Ltek
 - [x] **`Clickable Sensors`**: individual sensors in info section open more info dialog - thanks @enrico-semrau
+- [x] **`Threshold-Based Icon Coloring`**: dynamic icon colors based on sensor values with configurable thresholds and operators - thanks @fusionstream, @marcokreeft87
 
 ## Contributing
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -55,7 +55,7 @@ See [default entities](#default-entities)
 | features       | list             | See below                  | Optional flags to toggle different features                  |
 | sensor_layout  | string           | `default`                  | Layout for sensor display: `default`, `stacked`, or `bottom` |
 | sensor_classes | array            | See below                  | Device classes to average and display sensor readings for    |
-| thresholds     | object           | `80° / 60%`                | Temperature, humidity, and mold thresholds                   |
+| thresholds     | object           | `80° / 60%`                | Climate thresholds for temperature, humidity, and mold      |
 | styles         | object           | `{}`                       | Custom CSS styles for card areas                             |
 
 ### Default Entities
@@ -119,6 +119,14 @@ entities:
   - entity_id: switch.fan
     on_color: blue
     off_color: disabled
+  - entity_id: sensor.battery_level
+    thresholds:
+      - threshold: 80
+        icon_color: green
+      - threshold: 50
+        icon_color: orange
+      - threshold: 20
+        icon_color: red
 ```
 
 ## Custom Styles

--- a/docs/configuration/ENTITY-COLOR-CONFIGURATION.md
+++ b/docs/configuration/ENTITY-COLOR-CONFIGURATION.md
@@ -52,15 +52,53 @@ entities:
     off_color: '#404040' # Dark grey
 ```
 
+### 3. Threshold-Based Colors
+
+![Thresholds](../../assets/thresholds.gif)
+
+Configure dynamic colors based on numeric sensor values:
+
+```yaml
+entities:
+  - entity_id: sensor.battery_level
+    thresholds:
+      - threshold: 80
+        icon_color: green
+      - threshold: 50
+        icon_color: orange
+      - threshold: 20
+        icon_color: red
+```
+
+**Advanced operators:**
+
+```yaml
+entities:
+  - entity_id: sensor.temperature
+    thresholds:
+      - threshold: 25
+        icon_color: red
+        operator: gt # above 25°C
+      - threshold: 15
+        icon_color: green
+        operator: gte # 15-25°C
+      - threshold: 15
+        icon_color: blue
+        operator: lt # below 15°C
+```
+
+**Supported operators:** `gt` (>), `gte` (>=), `lt` (<), `lte` (<=), `eq` (=). Default is `gte`.
+
 ## Color Priority
 
 Colors are applied in this priority order:
 
-1. **Card config** (`entity.on_color`, `entity.off_color`, `entity.icon_color`)
-2. **Entity attributes** (`customize.yaml` settings)
-3. **RGB colors** (from entity's `rgb_color` attribute)
-4. **Theme colors** (automatic theme-based colors)
-5. **Domain colors** (default colors by entity domain)
+1. **Threshold colors** (based on sensor values)
+2. **Card config** (`entity.on_color`, `entity.off_color`, `entity.icon_color`)
+3. **Entity attributes** (`customize.yaml` settings)
+4. **RGB colors** (from entity's `rgb_color` attribute)
+5. **Theme colors** (automatic theme-based colors)
+6. **Domain colors** (default colors by entity domain)
 
 ## Examples
 
@@ -101,6 +139,59 @@ entities:
     icon: mdi:power-socket
     on_color: '#1BA3E0' # TP-Link blue
     off_color: grey
+```
+
+### Battery Level Indicators
+
+```yaml
+entities:
+  - entity_id: sensor.phone_battery
+    icon: mdi:battery
+    thresholds:
+      - threshold: 80
+        icon_color: green
+      - threshold: 50
+        icon_color: orange
+      - threshold: 30
+        icon_color: amber
+      - threshold: 15
+        icon_color: red
+```
+
+### Temperature Zones
+
+```yaml
+entities:
+  - entity_id: sensor.living_room_temperature
+    icon: mdi:thermometer
+    thresholds:
+      - threshold: 24
+        icon_color: red
+        operator: gt # Too hot
+      - threshold: 20
+        icon_color: green
+        operator: gte # Comfortable range
+      - threshold: 18
+        icon_color: blue
+        operator: lt # Too cold
+```
+
+### Humidity Control
+
+```yaml
+entities:
+  - entity_id: sensor.bathroom_humidity
+    icon: mdi:water-percent
+    thresholds:
+      - threshold: 70
+        icon_color: red
+        operator: gt # High humidity
+      - threshold: 40
+        icon_color: green
+        operator: gte # Normal range
+      - threshold: 30
+        icon_color: orange
+        operator: lt # Low humidity
 ```
 
 ## Advanced Usage

--- a/docs/configuration/ENTITY-CONFIGURATION.md
+++ b/docs/configuration/ENTITY-CONFIGURATION.md
@@ -28,24 +28,26 @@ entities:
 
 ## Entity Configuration Options
 
-| Name              | Type   | Default                 | Description                   |
-| ----------------- | ------ | ----------------------- | ----------------------------- |
-| entity_id         | string | **Required**            | Entity ID in Home Assistant   |
-| icon              | string | entity default          | Custom MDI icon               |
-| on_color          | string | domain default          | Color when entity is active   |
-| off_color         | string | theme off color         | Color when entity is inactive |
-| tap_action        | object | `{action: "toggle"}`    | Action on single tap          |
-| hold_action       | object | `{action: "more-info"}` | Action on hold                |
-| double_tap_action | object | `{action: "none"}`      | Action on double tap          |
+| Name              | Type   | Default                 | Description                           |
+| ----------------- | ------ | ----------------------- | ------------------------------------- |
+| entity_id         | string | **Required**            | Entity ID in Home Assistant           |
+| icon              | string | entity default          | Custom MDI icon                       |
+| on_color          | string | domain default          | Color when entity is active           |
+| off_color         | string | theme off color         | Color when entity is inactive         |
+| thresholds        | array  | none                    | Dynamic colors based on sensor values |
+| tap_action        | object | `{action: "toggle"}`    | Action on single tap                  |
+| hold_action       | object | `{action: "more-info"}` | Action on hold                        |
+| double_tap_action | object | `{action: "none"}`      | Action on double tap                  |
 
 ## Color Priority
 
 Colors are applied in this order:
 
-1. **Entity config** (`on_color`, `off_color`)
-2. **Entity attributes** (set via `customize.yaml`)
-3. **Theme colors** (minimalist or HA colors)
-4. **Domain defaults** (automatic colors by entity type)
+1. **Threshold colors** (based on sensor values)
+2. **Entity config** (`on_color`, `off_color`)
+3. **Entity attributes** (set via `customize.yaml`)
+4. **Theme colors** (minimalist or HA colors)
+5. **Domain defaults** (automatic colors by entity type)
 
 ## Color Examples
 
@@ -66,6 +68,17 @@ entities:
     icon: mdi:garage
     on_color: amber
     off_color: grey
+
+  # Battery sensor with threshold-based colors
+  - entity_id: sensor.phone_battery
+    icon: mdi:battery
+    thresholds:
+      - threshold: 80
+        icon_color: green
+      - threshold: 50
+        icon_color: orange
+      - threshold: 20
+        icon_color: red
 ```
 
 For theme color names and advanced customization, see [Entity Color Configuration](ENTITY-COLOR-CONFIGURATION.md).

--- a/docs/configuration/THRESHOLD-CONFIGURATION.md
+++ b/docs/configuration/THRESHOLD-CONFIGURATION.md
@@ -1,6 +1,8 @@
-## Threshold Configuration
+## Climate Threshold Configuration
 
 Configure climate-based border styling thresholds and mold detection:
+
+> **Note:** This covers **climate thresholds** for card styling. For **entity threshold colors** based on individual sensor values, see [Entity Color Configuration](ENTITY-COLOR-CONFIGURATION.md#3-threshold-based-colors).
 
 ```yaml
 thresholds:

--- a/src/cards/components/sensor-collection/styles.ts
+++ b/src/cards/components/sensor-collection/styles.ts
@@ -12,6 +12,8 @@ export const styles = css`
     opacity: var(--text-opacity-theme, 0.4);
     margin-left: -2%;
     margin-top: 1%;
+    position: relative;
+    z-index: 10; /* Ensure sensor collection appears above room entity */
   }
 
   :host([hide-icons]) {
@@ -37,7 +39,7 @@ export const styles = css`
     --mdc-icon-size: var(--user-sensor-icon-size, 20px);
     cursor: pointer;
     position: relative;
-    z-index: 0; /* create stacking context for ::before */
+    z-index: 1; /* Ensure sensors are above room entity and create stacking context for ::before */
     border-radius: 6px;
     transition:
       transform 150ms ease,

--- a/src/theme/custom-theme.ts
+++ b/src/theme/custom-theme.ts
@@ -2,16 +2,18 @@ import type { HomeAssistant } from '@hass/types';
 import type { EntityInformation } from '@type/room';
 import { processHomeAssistantColors, processMinimalistColors } from './colors';
 import { getRgbColor } from './get-rgb';
+import { getThresholdColor } from './threshold-color';
 
 /**
  * Determines the appropriate theme color override for a given entity based on its state,
  * configuration, and the current Home Assistant theme.
  *
  * The function prioritizes the following sources for the color:
- * 1. The `icon_color` attribute if it is a hex color.
- * 2. The entity's `on_color` or `off_color` configuration or state attributes, processed via `getRgbColor`.
- * 3. Minimalist theme-specific color processing if the active theme starts with "minimalist-".
- * 4. Fallback to Home Assistant's default color processing.
+ * 1. Threshold-based colors from entity configuration.
+ * 2. The `icon_color` attribute if it is a hex color.
+ * 3. The entity's `on_color` or `off_color` configuration or state attributes, processed via `getRgbColor`.
+ * 4. Minimalist theme-specific color processing if the active theme starts with "minimalist-".
+ * 5. Fallback to Home Assistant's default color processing.
  *
  * @param hass - The Home Assistant instance containing theme information.
  * @param entity - The entity information, including state and configuration.
@@ -26,7 +28,13 @@ export const getThemeColorOverride = (
   const { state } = entity;
   if (!state) return undefined;
 
-  // icon color is the first priority - hex colors
+  // threshold-based colors have the highest priority
+  const thresholdColor = getThresholdColor(entity);
+  if (thresholdColor) {
+    return thresholdColor;
+  }
+
+  // icon color is the second priority - hex colors
   const iconColor = state.attributes.icon_color;
   if (iconColor?.startsWith('#')) {
     return iconColor;

--- a/src/theme/threshold-color.ts
+++ b/src/theme/threshold-color.ts
@@ -1,0 +1,60 @@
+import type { EntityInformation } from '@type/room';
+import type { ThresholdConfig } from '@type/config';
+
+/**
+ * Evaluates threshold conditions and returns the appropriate color
+ *
+ * @param entity - The entity information containing state and config
+ * @returns The color string if a threshold matches, undefined otherwise
+ */
+export const getThresholdColor = (entity: EntityInformation): string | undefined => {
+  const { config, state } = entity;
+
+  if (!config.thresholds || !state) {
+    return undefined;
+  }
+
+  const numericValue = parseFloat(state.state);
+
+  // Skip if state is not a valid number
+  if (isNaN(numericValue)) {
+    return undefined;
+  }
+
+  // Sort thresholds by value in descending order to check highest first
+  const sortedThresholds = [...config.thresholds].sort((a, b) => b.threshold - a.threshold);
+
+  for (const threshold of sortedThresholds) {
+    if (meetsThreshold(numericValue, threshold)) {
+      return threshold.icon_color;
+    }
+  }
+
+  return undefined;
+};
+
+/**
+ * Checks if a numeric value meets a threshold condition
+ *
+ * @param value - The numeric value to test
+ * @param threshold - The threshold configuration
+ * @returns true if the condition is met
+ */
+const meetsThreshold = (value: number, threshold: ThresholdConfig): boolean => {
+  const operator = threshold.operator || 'gte';
+
+  switch (operator) {
+    case 'gt':
+      return value > threshold.threshold;
+    case 'gte':
+      return value >= threshold.threshold;
+    case 'lt':
+      return value < threshold.threshold;
+    case 'lte':
+      return value <= threshold.threshold;
+    case 'eq':
+      return value === threshold.threshold;
+    default:
+      return value >= threshold.threshold;
+  }
+};

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -124,6 +124,9 @@ export interface EntityConfig {
   /** Custom color for the off state */
   off_color?: string;
 
+  /** Threshold-based color configuration */
+  thresholds?: ThresholdConfig[];
+
   /** Action to perform on tap */
   tap_action?: ActionConfig;
 
@@ -132,6 +135,20 @@ export interface EntityConfig {
 
   /** Action to perform on double tap */
   double_tap_action?: ActionConfig;
+}
+
+/**
+ * Configuration for threshold-based coloring
+ */
+export interface ThresholdConfig {
+  /** Threshold value to compare against entity state */
+  threshold: number;
+
+  /** Color to use when this threshold condition is met */
+  icon_color: string;
+
+  /** Comparison operator (default: 'gte' for greater than or equal) */
+  operator?: 'gt' | 'gte' | 'lt' | 'lte' | 'eq';
 }
 
 /**

--- a/test/theme/threshold-color.spec.ts
+++ b/test/theme/threshold-color.spec.ts
@@ -1,0 +1,143 @@
+import { getThresholdColor } from '@theme/threshold-color';
+import type { EntityInformation } from '@type/room';
+import type { ThresholdConfig } from '@type/config';
+import { expect } from 'chai';
+
+describe('threshold-color.ts', () => {
+  describe('getThresholdColor', () => {
+    const createEntity = (
+      state: string,
+      thresholds?: ThresholdConfig[]
+    ): EntityInformation => ({
+      config: {
+        entity_id: 'sensor.test',
+        thresholds,
+      },
+      state: {
+        entity_id: 'sensor.test',
+        state,
+        domain: 'sensor',
+        attributes: {},
+      },
+    });
+
+    it('should return undefined when no thresholds configured', () => {
+      const entity = createEntity('25');
+      const result = getThresholdColor(entity);
+      expect(result).to.be.undefined;
+    });
+
+    it('should return undefined when state is undefined', () => {
+      const entity = {
+        config: {
+          entity_id: 'sensor.test',
+          thresholds: [{ threshold: 50, icon_color: 'green' }],
+        },
+        state: undefined,
+      };
+      const result = getThresholdColor(entity);
+      expect(result).to.be.undefined;
+    });
+
+    it('should return undefined for non-numeric states', () => {
+      const entity = createEntity('unavailable', [
+        { threshold: 50, icon_color: 'green' }
+      ]);
+      const result = getThresholdColor(entity);
+      expect(result).to.be.undefined;
+    });
+
+    it('should match threshold with default gte operator', () => {
+      const entity = createEntity('75', [
+        { threshold: 80, icon_color: 'green' },
+        { threshold: 50, icon_color: 'orange' },
+        { threshold: 20, icon_color: 'red' }
+      ]);
+      const result = getThresholdColor(entity);
+      expect(result).to.equal('orange');
+    });
+
+    it('should match highest applicable threshold first', () => {
+      const entity = createEntity('85', [
+        { threshold: 80, icon_color: 'green' },
+        { threshold: 50, icon_color: 'orange' }
+      ]);
+      const result = getThresholdColor(entity);
+      expect(result).to.equal('green');
+    });
+
+    it('should work with gt operator', () => {
+      const entity = createEntity('25', [
+        { threshold: 25, icon_color: 'red', operator: 'gt' }
+      ]);
+      const result = getThresholdColor(entity);
+      expect(result).to.be.undefined; // 25 is not > 25
+
+      const entity2 = createEntity('26', [
+        { threshold: 25, icon_color: 'red', operator: 'gt' }
+      ]);
+      const result2 = getThresholdColor(entity2);
+      expect(result2).to.equal('red');
+    });
+
+    it('should work with lt operator', () => {
+      const entity = createEntity('15', [
+        { threshold: 20, icon_color: 'blue', operator: 'lt' }
+      ]);
+      const result = getThresholdColor(entity);
+      expect(result).to.equal('blue');
+    });
+
+    it('should work with lte operator', () => {
+      const entity = createEntity('20', [
+        { threshold: 20, icon_color: 'blue', operator: 'lte' }
+      ]);
+      const result = getThresholdColor(entity);
+      expect(result).to.equal('blue');
+    });
+
+    it('should work with eq operator', () => {
+      const entity = createEntity('50', [
+        { threshold: 50, icon_color: 'yellow', operator: 'eq' }
+      ]);
+      const result = getThresholdColor(entity);
+      expect(result).to.equal('yellow');
+    });
+
+    it('should handle decimal values', () => {
+      const entity = createEntity('23.5', [
+        { threshold: 25.0, icon_color: 'red', operator: 'gt' },
+        { threshold: 20.0, icon_color: 'green', operator: 'gte' }
+      ]);
+      const result = getThresholdColor(entity);
+      expect(result).to.equal('green');
+    });
+
+    it('should return undefined when no thresholds match', () => {
+      const entity = createEntity('10', [
+        { threshold: 50, icon_color: 'green' },
+        { threshold: 30, icon_color: 'orange' }
+      ]);
+      const result = getThresholdColor(entity);
+      expect(result).to.be.undefined;
+    });
+
+    it('should process temperature range example correctly', () => {
+      const thresholds: ThresholdConfig[] = [
+        { threshold: 25, icon_color: 'red', operator: 'gt' },
+        { threshold: 15, icon_color: 'green', operator: 'gte' },
+        { threshold: 15, icon_color: 'blue', operator: 'lt' }
+      ];
+
+      // Above 25°C = red
+      expect(getThresholdColor(createEntity('26', thresholds))).to.equal('red');
+
+      // 15-25°C = green
+      expect(getThresholdColor(createEntity('20', thresholds))).to.equal('green');
+      expect(getThresholdColor(createEntity('15', thresholds))).to.equal('green');
+
+      // Below 15°C = blue
+      expect(getThresholdColor(createEntity('10', thresholds))).to.equal('blue');
+    });
+  });
+});


### PR DESCRIPTION
## New Features

### 🎨 Threshold-Based Icon Coloring

You can now configure dynamic icon colors based on sensor values using thresholds. This allows for more intuitive visual feedback - for example, showing battery levels with green/orange/red colors, or temperature sensors that change color based on ranges.

![Thresholds](https://raw.githubusercontent.com/homeassistant-extras/room-summary-card/main/assets/thresholds.gif)

**Configuration:**

```yaml
type: custom:room-summary-card
entities:
  - entity_id: sensor.battery_level
    thresholds:
      - threshold: 80
        icon_color: green
      - threshold: 50
        icon_color: orange
      - threshold: 20
        icon_color: red
```

**Advanced usage with operators:**

```yaml
entities:
  - entity_id: sensor.temperature
    thresholds:
      - threshold: 25
        icon_color: red
        operator: gt # above 25°C
      - threshold: 15
        icon_color: green
        operator: gte # 15-25°C
      - threshold: 15
        icon_color: blue
        operator: lt # below 15°C
```

**Supported operators:** `gt` (>), `gte` (>=), `lt` (<), `lte` (<=), `eq` (=). Default is `gte`.

Thresholds are evaluated in descending order, with the first matching condition determining the color. This feature takes highest priority over existing color configurations.

**📚 Documentation:**

- [Entity Color Configuration Guide](../docs/configuration/ENTITY-COLOR-CONFIGURATION.md#3-threshold-based-colors) - Complete threshold configuration reference
- [Entity Configuration Reference](../docs/configuration/ENTITY-CONFIGURATION.md) - Updated with threshold configuration options

## Bug Fixes

### 🐛 Room Entity Sensor Click Issues

Fixed an issue where room entity icons could overlap with sensors, preventing sensor clicks from registering properly in some layout configurations.
