### PR TITLE
Add ignore_entity feature - useful for auto-entities edge case.  🦯 📽️ 

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ See the [Theming Guide](docs/THEMING.md) for detailed color configuration and cu
 - [x] **`Sensor layout options`**: flexible sensor display layouts (default, stacked, bottom) - thanks @Ltek, @zoic21
 - [x] **`Sensor averaging by device class`**: automatic averaging like HA area card - thanks @Ltek
 - [x] **`Moving away from customize.yaml`**: allowing more configuration on the card - thanks @johntdyer
-- [x] **`Area, entity, and custom backgrounds`**: can setup backgrounds and customize - thanks @CalamarBicefalo, @X1pheR, @Ltek
+- [x] **`Area, entity, and custom backgrounds`**: can setup backgrounds and customize - thanks @CalamarBicefalo, @X1pheR, @Ltek, @felippepuhle
 - [x] **`Custom Styles`**: ability to apply custom CSS styles - thanks @marceloroloff, @ma-gu-16, @Ltek, @johannwilken, @Sturby
 - [x] **`Random bugs`**: pointing out issues to improve card - thanks @rickd1994, @avijavez10, @awfulwoman, @anandv85
 - [x] **`Occupancy Detection`**: visual indicators for room occupancy with motion/occupancy sensors - thanks @X1pheR

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -87,20 +87,28 @@ features:
   - skip_climate_styles
   - skip_entity_styles
   - multi_light_background
+  - ignore_entity
 ```
 
-| Feature                  | Description                                                 |
-| ------------------------ | ----------------------------------------------------------- |
-| hide_climate_label       | Hide the climate/sensor information                         |
-| hide_area_stats          | Hide the area statistics (device/entity counts)             |
-| hide_room_icon           | Hide the room icon (for cleaner layouts)                    |
-| hide_sensor_icons        | Hide the icons next to sensor values                        |
-| hide_sensor_labels       | Hide the labels next to sensor icons (opposite of hide_sensor_icons) |
-| exclude_default_entities | Don't include default light/fan entities                    |
-| skip_climate_styles      | Disable climate-based color coding & borders                |
-| skip_entity_styles       | Disable card background styling based on main entity        |
-| show_entity_labels       | Show entity labels under each entity icon                   |
-| multi_light_background   | Enable background lighting when any light in the room is on |
+| Feature                  | Description                                                                                    |
+| ------------------------ | ---------------------------------------------------------------------------------------------- |
+| hide_climate_label       | Hide the climate/sensor information                                                            |
+| hide_area_stats          | Hide the area statistics (device/entity counts)                                                |
+| hide_room_icon           | Hide the room icon (for cleaner layouts)                                                       |
+| hide_sensor_icons        | Hide the icons next to sensor values                                                           |
+| hide_sensor_labels       | Hide the labels next to sensor icons (opposite of hide_sensor_icons)                           |
+| exclude_default_entities | Don't include default light/fan entities                                                       |
+| skip_climate_styles      | Disable climate-based color coding & borders                                                   |
+| skip_entity_styles       | Disable card background styling based on main entity                                           |
+| show_entity_labels       | Show entity labels under each entity icon                                                      |
+| multi_light_background   | Enable background lighting when any light in the room is on                                    |
+| ignore_entity            | Ignore the custom entity configuration and use default room entity (useful with auto-entities) |
+
+### Using `ignore_entity` with Auto-Entities
+
+The `ignore_entity` feature is particularly useful when using the `auto-entities` card to automatically generate room cards. It allows you to specify an entity in the auto-entities configuration while still using the default room entity for the card display.
+
+See [Ignore Entities](./configuration/IGNORE-ENTITY.md) documentation.
 
 ## Sensor Classes
 

--- a/docs/configuration/IGNORE-ENTITY.md
+++ b/docs/configuration/IGNORE-ENTITY.md
@@ -1,0 +1,37 @@
+# Ignore Entity Feature
+
+The `ignore_entity` feature flag allows you to ignore a custom entity configuration and use the default room entity instead.
+
+## Use Case
+
+This feature is particularly useful when using the `auto-entities` card to automatically generate room cards. It allows you to specify an entity in the auto-entities configuration for filtering or sorting purposes, while still using the default room entity for the card display.
+
+## Example
+
+```yaml
+type: custom:auto-entities
+entities:
+  - entity: person.gina
+    type: custom:room-summary-card
+    area: dining_room
+    features:
+     - ignore_entity
+  - entity: input_boolean.gina_mute
+    type: custom:room-summary-card
+    area: living_room
+    features:
+     - ignore_entity
+sort:
+  method: state
+  reverse: true
+```
+
+In this example, the cards are filtered and sorted based on the specified entities (`person.gina` and `input_boolean.gina_mute`), but the card will display using the default room entity (`light.{area}_light`) instead of the specified entity.
+
+## How It Works
+
+When `ignore_entity` is enabled:
+- The `entity` configuration is ignored
+- The card uses the default room entity based on the area (`light.{area}_light`)
+- The card displays with the default room icon and behavior
+

--- a/src/delegates/entities/room-entity.ts
+++ b/src/delegates/entities/room-entity.ts
@@ -1,3 +1,4 @@
+import { hasFeature } from '@config/feature';
 import { getArea } from '@delegates/retrievers/area';
 import { getState } from '@delegates/retrievers/state';
 import type { ActionConfig } from '@hass/data/lovelace/config/action';
@@ -48,7 +49,7 @@ export const getRoomEntity = (
   };
 
   // Handle different entity configuration formats
-  if (config.entity) {
+  if (config.entity && !hasFeature(config, 'ignore_entity')) {
     if (typeof config.entity === 'string') {
       // String format
       return {

--- a/src/editor/schema-constants.ts
+++ b/src/editor/schema-constants.ts
@@ -73,6 +73,10 @@ export const FEATURES: HaFormSchema = {
               label: 'Multi-Light Background',
               value: 'multi_light_background',
             },
+            {
+              label: 'Ignore Entity',
+              value: 'ignore_entity',
+            },
           ],
         },
       },

--- a/src/types/config/index.ts
+++ b/src/types/config/index.ts
@@ -114,6 +114,7 @@ export type Features =
   | 'hide_room_icon'
   | 'hide_sensor_icons'
   | 'hide_sensor_labels'
+  | 'ignore_entity'
   | 'exclude_default_entities'
   | 'skip_climate_styles'
   | 'skip_entity_styles'

--- a/test/delegates/entities/room-entity.spec.ts
+++ b/test/delegates/entities/room-entity.spec.ts
@@ -248,4 +248,37 @@ describe('room-entity.ts', () => {
       expectedActionConfig.double_tap_action,
     );
   });
+
+  it('should ignore custom entity when ignore_entity feature is enabled', () => {
+    const config: Config = {
+      area: 'test_room',
+      entity: 'light.custom_entity',
+      features: ['ignore_entity'],
+    };
+
+    const roomEntity = getRoomEntity(mockHass, config);
+
+    // Should return default room entity instead of custom entity
+    expect(roomEntity.config.entity_id).to.equal('light.test_room_light');
+    expect(roomEntity.config.icon).to.equal('mdi:room');
+    expect(roomEntity.state?.state).to.equal('on');
+  });
+
+  it('should ignore custom entity object when ignore_entity feature is enabled', () => {
+    const config: Config = {
+      area: 'test_room',
+      entity: {
+        entity_id: 'light.custom_entity',
+        icon: 'mdi:override',
+      },
+      features: ['ignore_entity'],
+    };
+
+    const roomEntity = getRoomEntity(mockHass, config);
+
+    // Should return default room entity instead of custom entity
+    expect(roomEntity.config.entity_id).to.equal('light.test_room_light');
+    expect(roomEntity.config.icon).to.equal('mdi:room');
+    expect(roomEntity.state?.state).to.equal('on');
+  });
 });

--- a/test/editor/editor-schema.spec.ts
+++ b/test/editor/editor-schema.spec.ts
@@ -296,6 +296,10 @@ describe('editor-schema.ts', () => {
                       label: 'Multi-Light Background',
                       value: 'multi_light_background',
                     },
+                    {
+                      label: 'Ignore Entity',
+                      value: 'ignore_entity',
+                    },
                   ],
                 },
               },


### PR DESCRIPTION
## New Feature: `ignore_entity`

Added the `ignore_entity` feature flag to ignore custom entity configuration and use the default room entity instead. This is particularly useful when using `auto-entities` to filter or sort cards while still displaying the default room entity.

**Example:**
```yaml
type: custom:auto-entities
entities:
  - entity: person.gina
    type: custom:room-summary-card
    area: dining_room
    features:
     - ignore_entity
sort:
  method: state
  reverse: true
```

