### PR TITLE
Speed improvements suggested by AI

### DIFF
--- a/src/cards/card.ts
+++ b/src/cards/card.ts
@@ -19,9 +19,16 @@ import {
   handleClickAction,
 } from '@delegates/action-handler-delegate';
 import type { ClimateThresholds } from '@delegates/checks/thresholds';
-import { getRoomProperties } from '@delegates/utils/setup-card';
+import {
+  collectRelevantEntityIds,
+  getRoomProperties,
+} from '@delegates/utils/setup-card';
 import { fireEvent } from '@hass/common/dom/fire_event';
 import type { HomeAssistant } from '@hass/types';
+import type { HassEntities } from '@hass/ws/types';
+import type { EntityRegistryDisplayEntry } from '@hass/data/entity_registry';
+import type { DeviceRegistryEntry } from '@hass/data/device_registry';
+import type { AreaRegistryEntry } from '@hass/data/area/area_registry';
 import { info } from '@html/info';
 import { renderCardStyles } from '@theme/render/card-styles';
 import { styles } from '@theme/styles';
@@ -110,6 +117,17 @@ export class RoomSummaryCard extends LitElement {
   private _hass!: HomeAssistant;
 
   /**
+   * Cached references for early-exit change detection.
+   * Avoids running expensive getRoomProperties() when no relevant state changed.
+   */
+  private _prevStates?: HassEntities;
+  private _prevEntities?: Record<string, EntityRegistryDisplayEntry>;
+  private _prevDevices?: Record<string, DeviceRegistryEntry>;
+  private _prevAreas?: Record<string, AreaRegistryEntry>;
+  private _relevantEntityIds?: Set<string>;
+  private _prevHass?: HomeAssistant;
+
+  /**
    * Returns the component's styles
    */
   static override get styles(): CSSResult {
@@ -136,6 +154,54 @@ export class RoomSummaryCard extends LitElement {
    */
   set hass(hass: HomeAssistant) {
     d(this._config, 'room-summary-card', 'set hass');
+
+    // Early-exit: skip expensive getRoomProperties() if no relevant state changed.
+    // In HA, hass.states is a new object on every update, but individual entity
+    // state objects within it are only replaced when that specific entity changes.
+    // By checking only the entities relevant to this card, we avoid O(N) work
+    // on every unrelated state change.
+    const registriesChanged =
+      hass.entities !== this._prevEntities ||
+      hass.devices !== this._prevDevices ||
+      hass.areas !== this._prevAreas;
+
+    if (
+      !registriesChanged &&
+      this._relevantEntityIds &&
+      this._prevStates &&
+      this._hass &&
+      hass !== this._prevHass
+    ) {
+      let anyRelevantStateChanged = false;
+      for (const id of this._relevantEntityIds) {
+        if (hass.states[id] !== this._prevStates[id]) {
+          anyRelevantStateChanged = true;
+          break;
+        }
+      }
+
+      if (!anyRelevantStateChanged) {
+        this._prevStates = hass.states;
+        this._prevHass = hass;
+        // Still need to forward formatEntityState changes
+        if (hass.formatEntityState !== this._hass.formatEntityState) {
+          this._hass = hass;
+        } else {
+          // update children who are subscribed
+          fireEvent(this, 'hass-update', { hass });
+        }
+        return;
+      }
+    }
+
+    // Cache registry references for next comparison
+    this._prevHass = hass;
+    this._prevStates = hass.states;
+    this._prevEntities = hass.entities;
+    this._prevDevices = hass.devices;
+    this._prevAreas = hass.areas;
+
+    const props = getRoomProperties(hass, this._config, this);
     const {
       roomInfo,
       roomEntity,
@@ -145,7 +211,10 @@ export class RoomSummaryCard extends LitElement {
       isIconActive,
       thresholds,
       flags: { alarm, dark, frostedGlass },
-    } = getRoomProperties(hass, this._config, this);
+    } = props;
+
+    // Update the set of entity IDs we care about for future early-exit checks
+    this._relevantEntityIds = collectRelevantEntityIds(this._config, props);
 
     this.alarm = alarm;
     this.dark = dark;

--- a/src/cards/card.ts
+++ b/src/cards/card.ts
@@ -23,7 +23,6 @@ import {
   collectRelevantEntityIds,
   getRoomProperties,
 } from '@delegates/utils/setup-card';
-import { fireEvent } from '@hass/common/dom/fire_event';
 import type { HomeAssistant } from '@hass/types';
 import type { HassEntities } from '@hass/ws/types';
 import type { EntityRegistryDisplayEntry } from '@hass/data/entity_registry';
@@ -188,7 +187,7 @@ export class RoomSummaryCard extends LitElement {
           this._hass = hass;
         } else {
           // update children who are subscribed
-          fireEvent(this, 'hass-update', { hass });
+          this._dispatchHassUpdate(hass);
         }
         return;
       }
@@ -264,9 +263,25 @@ export class RoomSummaryCard extends LitElement {
       this._hass = hass;
     } else {
       // update children who are subscribed
-      fireEvent(this, 'hass-update', {
-        hass,
+      this._dispatchHassUpdate(hass);
+    }
+  }
+
+  /**
+   * Dispatches hass-update event to child components via the shadow root.
+   * This scopes the event so that only this card's children receive it,
+   * preventing cross-card event leakage when multiple room-summary-cards
+   * are on the same dashboard.
+   */
+  private _dispatchHassUpdate(hass: HomeAssistant): void {
+    const root = this.shadowRoot;
+    if (root) {
+      const event = new CustomEvent('hass-update', {
+        detail: { hass },
+        bubbles: false,
+        composed: false,
       });
+      root.dispatchEvent(event);
     }
   }
 

--- a/src/cards/mixins/hass-update-mixin.ts
+++ b/src/cards/mixins/hass-update-mixin.ts
@@ -51,15 +51,46 @@ export const HassUpdateMixin = <T extends Constructor<LitElement>>(
 
     override connectedCallback(): void {
       super.connectedCallback();
-      globalThis.addEventListener('hass-update', this._boundHassUpdateHandler);
+
+      // Listen on the component's root node (shadow root of the parent card)
+      // instead of globalThis. This scopes events so that each card's
+      // hass-update only reaches its own children, not components in other
+      // cards on the same dashboard.
+      const root =
+        typeof this.getRootNode === 'function'
+          ? this.getRootNode()
+          : undefined;
+      if (root && root !== this) {
+        root.addEventListener(
+          'hass-update',
+          this._boundHassUpdateHandler as EventListener,
+        );
+      } else {
+        // Fallback for components not in a shadow root
+        globalThis.addEventListener(
+          'hass-update',
+          this._boundHassUpdateHandler,
+        );
+      }
     }
 
     override disconnectedCallback(): void {
       super.disconnectedCallback();
-      globalThis.removeEventListener(
-        'hass-update',
-        this._boundHassUpdateHandler,
-      );
+      const root =
+        typeof this.getRootNode === 'function'
+          ? this.getRootNode()
+          : undefined;
+      if (root && root !== this) {
+        root.removeEventListener(
+          'hass-update',
+          this._boundHassUpdateHandler as EventListener,
+        );
+      } else {
+        globalThis.removeEventListener(
+          'hass-update',
+          this._boundHassUpdateHandler,
+        );
+      }
     }
 
     private _handleHassUpdate(event: Event): void {

--- a/src/delegates/utils/setup-card.ts
+++ b/src/delegates/utils/setup-card.ts
@@ -117,3 +117,94 @@ export const getRoomProperties = (
     },
   };
 };
+
+/**
+ * Collects all entity IDs that are relevant to this card's rendering.
+ * Used for early-exit optimization in the hass setter — if none of these
+ * entity states changed, we can skip the expensive getRoomProperties() call.
+ *
+ * @param config - The card configuration
+ * @param props - The computed room properties from getRoomProperties()
+ * @returns A Set of entity IDs that affect this card's output
+ */
+export const collectRelevantEntityIds = (
+  config: Config,
+  props: RoomProperties,
+): Set<string> => {
+  const ids = new Set<string>();
+
+  // Room entity
+  if (props.roomEntity.config.entity_id) {
+    ids.add(props.roomEntity.config.entity_id);
+  }
+
+  // Individual sensors
+  if (props.sensors.individual) {
+    for (const s of props.sensors.individual) {
+      ids.add(s.entity_id);
+    }
+  }
+
+  // Averaged sensors (all contributing states)
+  if (props.sensors.averaged) {
+    for (const avg of props.sensors.averaged) {
+      for (const s of avg.states) {
+        ids.add(s.entity_id);
+      }
+    }
+  }
+
+  // Problem sensors
+  if (props.sensors.problemSensors) {
+    for (const s of props.sensors.problemSensors) {
+      ids.add(s.entity_id);
+    }
+  }
+
+  // Light entities
+  if (props.sensors.lightEntities) {
+    for (const s of props.sensors.lightEntities) {
+      ids.add(s.entity_id);
+    }
+  }
+
+  // Ambient light entities
+  if (props.sensors.ambientLightEntities) {
+    for (const s of props.sensors.ambientLightEntities) {
+      ids.add(s.entity_id);
+    }
+  }
+
+  // Threshold sensors
+  if (props.sensors.thresholdSensors) {
+    for (const s of props.sensors.thresholdSensors) {
+      ids.add(s.entity_id);
+    }
+  }
+
+  // Mold sensor
+  if (props.sensors.mold) {
+    ids.add(props.sensors.mold.entity_id);
+  }
+
+  // Alarm entities (smoke, gas, water, occupancy)
+  for (const alarmConfig of [
+    config.smoke,
+    config.gas,
+    config.water,
+    config.occupancy,
+  ]) {
+    if (alarmConfig?.entities) {
+      for (const id of alarmConfig.entities) {
+        ids.add(id);
+      }
+    }
+  }
+
+  // Background image entity
+  if (config.background?.image_entity) {
+    ids.add(config.background.image_entity);
+  }
+
+  return ids;
+};

--- a/src/html/area-statistics.ts
+++ b/src/html/area-statistics.ts
@@ -7,6 +7,18 @@ import type { Config } from '@type/config';
 import { type TemplateResult, html, nothing } from 'lit';
 
 /**
+ * Cache for area statistics to avoid re-scanning all devices/entities on every render.
+ * Keyed by area ID, stores the last known registry references and computed counts.
+ */
+interface AreaStatsCache {
+  devices: Record<string, any>;
+  entities: Record<string, any>;
+  deviceCount: number;
+  entityCount: number;
+}
+const areaStatsCacheMap = new Map<string, AreaStatsCache>();
+
+/**
  * Gets statistics about devices and entities in the area
  *
  * @param {HomeAssistant} hass - The Home Assistant instance
@@ -20,18 +32,47 @@ export const renderAreaStatistics = (
 ): TemplateResult | typeof nothing => {
   if (!hass || hasFeature(config, 'hide_area_stats')) return nothing;
 
-  const devices = Object.keys(hass.devices).filter(
-    (k) => getDevice(hass.devices, k)!.area_id === config.area,
-  );
+  let deviceCount: number;
+  let entityCount: number;
 
-  const entities = Object.keys(hass.entities).filter((k) => {
-    const entity = getEntity(hass.entities, k)!;
-    return entity.area_id === config.area || devices.includes(entity.device_id);
-  });
+  // Check if we have a valid cache for this area
+  const cached = areaStatsCacheMap.get(config.area);
+  if (
+    cached &&
+    cached.devices === hass.devices &&
+    cached.entities === hass.entities
+  ) {
+    // Registry references haven't changed — use cached counts
+    deviceCount = cached.deviceCount;
+    entityCount = cached.entityCount;
+  } else {
+    // Recompute counts
+    const devices = Object.keys(hass.devices).filter(
+      (k) => getDevice(hass.devices, k)!.area_id === config.area,
+    );
+
+    const entities = Object.keys(hass.entities).filter((k) => {
+      const entity = getEntity(hass.entities, k)!;
+      return (
+        entity.area_id === config.area || devices.includes(entity.device_id)
+      );
+    });
+
+    deviceCount = devices.length;
+    entityCount = entities.length;
+
+    // Update cache
+    areaStatsCacheMap.set(config.area, {
+      devices: hass.devices,
+      entities: hass.entities,
+      deviceCount,
+      entityCount,
+    });
+  }
 
   const e = [
-    [devices.length, 'devices'],
-    [entities.length, 'entities'],
+    [deviceCount, 'devices'],
+    [entityCount, 'entities'],
   ]
     .filter((count) => count.length > 0)
     .map(([count, type]) => `${count} ${type}`)

--- a/src/theme/util/get-view-theme.ts
+++ b/src/theme/util/get-view-theme.ts
@@ -1,8 +1,19 @@
 import type { HomeAssistant } from '@hass/types';
 
 /**
+ * WeakMap cache for DOM traversal results.
+ * Maps an element to the cached hui-view-container reference (or null if not found).
+ * Using WeakMap so that entries are garbage-collected when elements are removed from DOM.
+ */
+const viewContainerCache = new WeakMap<Element, Element | null>();
+
+/**
  * Gets the view theme by traversing up the DOM from the given element to find hui-view-container.
  * Falls back to the global theme if no view theme is set or if no element is provided.
+ *
+ * The DOM traversal result is cached per element since the view container does not
+ * change between renders. The theme name is still read live from the container on
+ * each call, so theme switches are picked up immediately.
  *
  * @param element - The DOM element to start traversing from. If null/undefined, returns global theme.
  * @param hass - The Home Assistant instance
@@ -17,15 +28,25 @@ export const getViewTheme = (
     return hass.themes?.theme;
   }
 
+  // Check cache for the view container
+  if (viewContainerCache.has(element)) {
+    const cachedContainer = viewContainerCache.get(element);
+    if (cachedContainer) {
+      return (cachedContainer as any).theme || hass.themes?.theme;
+    }
+    // Cached as null = no container found previously
+    return hass.themes?.theme;
+  }
+
   // Traverse up the DOM to find hui-view-container
   let currentElement: Element | null = element;
 
   while (currentElement && currentElement !== document.body) {
     // Check if this is the hui-view-container
     if (currentElement.tagName === 'HUI-VIEW-CONTAINER') {
-      const viewContainer = currentElement as any;
-      // Return the view theme if set, otherwise fall back to global theme
-      return viewContainer.theme || hass.themes?.theme;
+      // Cache the container reference for this element
+      viewContainerCache.set(element, currentElement);
+      return (currentElement as any).theme || hass.themes?.theme;
     }
 
     // Move up the DOM tree, handling shadow DOM boundaries
@@ -42,6 +63,9 @@ export const getViewTheme = (
       currentElement = null;
     }
   }
+
+  // Cache null result = no container found
+  viewContainerCache.set(element, null);
 
   // Fallback to global theme if view container not found
   return hass.themes?.theme;

--- a/test/delegates/utils/setup-card.spec.ts
+++ b/test/delegates/utils/setup-card.spec.ts
@@ -518,4 +518,180 @@ describe('setup-card.ts', () => {
       });
     });
   });
+
+  describe('collectRelevantEntityIds', () => {
+    // Import the function under test
+    let collectRelevantEntityIds: typeof import('@delegates/utils/setup-card').collectRelevantEntityIds;
+
+    before(async () => {
+      const mod = await import('@delegates/utils/setup-card');
+      collectRelevantEntityIds = mod.collectRelevantEntityIds;
+    });
+
+    it('should include the room entity ID', () => {
+      const config: Config = { area: 'living_room' };
+      const props = {
+        roomEntity: { config: { entity_id: 'light.test' }, state: undefined },
+        sensors: {
+          individual: [],
+          averaged: [],
+          problemSensors: [],
+          lightEntities: [],
+          ambientLightEntities: [],
+          thresholdSensors: [],
+        },
+      } as any;
+
+      const ids = collectRelevantEntityIds(config, props);
+      expect(ids.has('light.test')).to.be.true;
+    });
+
+    it('should include individual sensor entity IDs', () => {
+      const config: Config = { area: 'living_room' };
+      const props = {
+        roomEntity: { config: { entity_id: 'light.test' }, state: undefined },
+        sensors: {
+          individual: [
+            { entity_id: 'sensor.temp_1' },
+            { entity_id: 'sensor.humidity_1' },
+          ],
+          averaged: [],
+          problemSensors: [],
+          lightEntities: [],
+          ambientLightEntities: [],
+          thresholdSensors: [],
+        },
+      } as any;
+
+      const ids = collectRelevantEntityIds(config, props);
+      expect(ids.has('sensor.temp_1')).to.be.true;
+      expect(ids.has('sensor.humidity_1')).to.be.true;
+    });
+
+    it('should include averaged sensor entity IDs', () => {
+      const config: Config = { area: 'living_room' };
+      const props = {
+        roomEntity: { config: { entity_id: 'light.test' }, state: undefined },
+        sensors: {
+          individual: [],
+          averaged: [
+            {
+              states: [
+                { entity_id: 'sensor.avg_1' },
+                { entity_id: 'sensor.avg_2' },
+              ],
+            },
+          ],
+          problemSensors: [],
+          lightEntities: [],
+          ambientLightEntities: [],
+          thresholdSensors: [],
+        },
+      } as any;
+
+      const ids = collectRelevantEntityIds(config, props);
+      expect(ids.has('sensor.avg_1')).to.be.true;
+      expect(ids.has('sensor.avg_2')).to.be.true;
+    });
+
+    it('should include alarm entity IDs from config', () => {
+      const config: Config = {
+        area: 'living_room',
+        smoke: { entities: ['binary_sensor.smoke_1'] },
+        occupancy: { entities: ['binary_sensor.motion_1', 'binary_sensor.motion_2'] },
+      };
+      const props = {
+        roomEntity: { config: { entity_id: 'light.test' }, state: undefined },
+        sensors: {
+          individual: [],
+          averaged: [],
+          problemSensors: [],
+          lightEntities: [],
+          ambientLightEntities: [],
+          thresholdSensors: [],
+        },
+      } as any;
+
+      const ids = collectRelevantEntityIds(config, props);
+      expect(ids.has('binary_sensor.smoke_1')).to.be.true;
+      expect(ids.has('binary_sensor.motion_1')).to.be.true;
+      expect(ids.has('binary_sensor.motion_2')).to.be.true;
+    });
+
+    it('should include background image entity from config', () => {
+      const config: Config = {
+        area: 'living_room',
+        background: { image_entity: 'camera.front_door' },
+      };
+      const props = {
+        roomEntity: { config: { entity_id: 'light.test' }, state: undefined },
+        sensors: {
+          individual: [],
+          averaged: [],
+          problemSensors: [],
+          lightEntities: [],
+          ambientLightEntities: [],
+          thresholdSensors: [],
+        },
+      } as any;
+
+      const ids = collectRelevantEntityIds(config, props);
+      expect(ids.has('camera.front_door')).to.be.true;
+    });
+
+    it('should include mold sensor entity ID', () => {
+      const config: Config = { area: 'living_room' };
+      const props = {
+        roomEntity: { config: { entity_id: 'light.test' }, state: undefined },
+        sensors: {
+          individual: [],
+          averaged: [],
+          problemSensors: [],
+          lightEntities: [],
+          ambientLightEntities: [],
+          thresholdSensors: [],
+          mold: { entity_id: 'sensor.mold_indicator' },
+        },
+      } as any;
+
+      const ids = collectRelevantEntityIds(config, props);
+      expect(ids.has('sensor.mold_indicator')).to.be.true;
+    });
+
+    it('should handle missing sensor arrays gracefully', () => {
+      const config: Config = { area: 'living_room' };
+      const props = {
+        roomEntity: { config: { entity_id: 'light.test' }, state: undefined },
+        sensors: {
+          individual: [],
+          averaged: [],
+          problemSensors: [],
+        },
+      } as any;
+
+      const ids = collectRelevantEntityIds(config, props);
+      expect(ids.has('light.test')).to.be.true;
+      expect(ids.size).to.equal(1);
+    });
+
+    it('should include light and ambient light entity IDs', () => {
+      const config: Config = { area: 'living_room' };
+      const props = {
+        roomEntity: { config: { entity_id: 'light.test' }, state: undefined },
+        sensors: {
+          individual: [],
+          averaged: [],
+          problemSensors: [],
+          lightEntities: [{ entity_id: 'light.main' }],
+          ambientLightEntities: [{ entity_id: 'light.ambient' }],
+          thresholdSensors: [{ entity_id: 'sensor.threshold_temp' }],
+        },
+      } as any;
+
+      const ids = collectRelevantEntityIds(config, props);
+      expect(ids.has('light.main')).to.be.true;
+      expect(ids.has('light.ambient')).to.be.true;
+      expect(ids.has('sensor.threshold_temp')).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
## Description

Three targeted performance optimizations to reduce unnecessary work in the `set hass()` hot path and render cycle. These changes are most impactful on mobile devices (Companion App) and dashboards with multiple room-summary-cards.

### 1. Early-exit in `set hass()` when no relevant entity changed

**Problem:** Every `hass` update (triggered by *any* entity state change across HA) ran the full `getRoomProperties()` pipeline, which includes `getSensors()` iterating over all entities via `Object.values(hass.entities)`. On a typical HA instance with 500–2000+ entities, this O(N) scan fired dozens of times per second for completely unrelated state changes.

**Fix:** Track which entity IDs are relevant to this card (room entity, sensors, lights, alarms, thresholds, etc.) via `collectRelevantEntityIds()`. On each `set hass()`, compare only those ~5–20 entity state references against the previous values. If none changed and the registries (entities/devices/areas) haven't been replaced, skip `getRoomProperties()` entirely.

**Files:** `src/cards/card.ts`, `src/delegates/utils/setup-card.ts`, `test/delegates/utils/setup-card.spec.ts`

### 2. Scope `hass-update` events to card shadow root

**Problem:** `hass-update` events were dispatched on `globalThis`, so every sub-component of every room-summary-card on the dashboard received every event — O(N cards × M children) event handlers firing per update.

**Fix:** The card now dispatches `hass-update` on its own `shadowRoot` (non-bubbling, non-composed). `HassUpdateMixin` listens on `getRootNode()` (the parent card's shadow root) with a `globalThis` fallback for elements not in a shadow tree. Each card's events now only reach its own children.

**Files:** `src/cards/card.ts`, `src/cards/mixins/hass-update-mixin.ts`

### 3. Cache `getViewTheme()` DOM traversal and `renderAreaStatistics()` counts

**Problem:**
- `getViewTheme()` traversed the DOM through shadow boundaries on every call to find `HUI-VIEW-CONTAINER` — the container never moves.
- `renderAreaStatistics()` filtered ALL devices and ALL entities to count those in the area on every render.

**Fix:**
- Cache the `HUI-VIEW-CONTAINER` reference per element using a `WeakMap`. The container position doesn't change; the theme name is still read live from the cached reference.
- Cache device/entity counts per area, invalidated only when the `hass.devices` or `hass.entities` registry reference changes.

**Files:** `src/theme/util/get-view-theme.ts`, `src/html/area-statistics.ts`

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- 1567 tests passing (1559 existing + 8 new tests for `collectRelevantEntityIds`)
- Build succeeds, CodeQL clean (0 alerts)

- [ ] Tested on Home Assistant version: <!-- Add version number -->
- [ ] Tested on browser(s): <!-- List browsers -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly

## Additional Notes

Each optimization is in a separate commit for easy review:
1. `3b58196` — early-exit in hass setter
2. `2572e2a` — scoped hass-update events
3. `371371a` — cached DOM traversal and area statistics

> [!CAUTION]
> Do not use the green merge buttons to merge into 'release' branch. Use the `/merge` command.