### PR TITLE
Label and badge templates 🏷️✨

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ This project is protected under the MIT License. For more details, refer to the 
 - [x] **`Random bugs`**: pointing out issues to improve card - thanks @rickd1994, @avijavez10, @awfulwoman, @anandv85
 - [x] **`Occupancy Detection`**: visual indicators for room occupancy with motion/occupancy sensors - thanks @X1pheR
 - [x] **`Mold Indicator`**: animated warning indicator for mold detection with threshold-based display - thanks @ma-gu-16, @Bacaliu
-- [x] **`Entity Labels`**: display entity names under icons for better identification - thanks @Ltek
+- [x] **`Entity Labels`**: display entity names under icons for better identification - thanks @Ltek, @guillochon
 - [x] **`Clickable Sensors`**: individual sensors in info section open more info dialog - thanks @enrico-semrau
 - [x] **`Threshold-Based Icon Coloring`**: dynamic icon colors based on sensor values with configurable thresholds and operators - thanks @fusionstream, @marcokreeft87, @a0365d9b
 - [x] **`State-Based Icon Coloring`**: exact state & attribute matching for sensors like washing machines, device trackers, and status indicators - thanks @marcokreeft87, @zoic21, and @sebashi!

--- a/README.md
+++ b/README.md
@@ -125,5 +125,5 @@ This project is protected under the MIT License. For more details, refer to the 
 - [x] **`Frosted Glass Theme Support`**: automatic detection and styling for Frosted Glass themes with transparent blurred card effects - thanks @devkaiwang
 - [x] **`Sensor Improvements`**: feature requests to make sensors awesome - thanks @MelleD, @bobo-cher
 - [x] **`Entity Sliders`**: entity transforms into slider - thanks @tmaihoff, @hfalk, @benjycov
-- [x] **`Entity Badges`**: dynamic badge overlays- thanks @ojm88
+- [x] **`Entity Badges`**: dynamic badge overlays - thanks @ojm88, @guillochon
 - [x] **`Performance`**: scope state-update events per card so dashboards with many rooms don't cross-wake each other - thanks @guillochon

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -11,6 +11,7 @@ Some of these go to their own documents - so use this ToC as a guide.
 - [Feature Flags](#feature-flags)
 - [Background Configuration](configuration/BACKGROUND-CONFIGURATION.md)
 - [Entity Configuration](configuration/ENTITY-CONFIGURATION.md)
+- [Label templates (Jinja)](configuration/LABEL-TEMPLATES.md)
 - [Badge Configuration](configuration/BADGE-CONFIGURATION.md)
 - [Entity Color Configuration](configuration/ENTITY-COLOR-CONFIGURATION.md)
 - [Sensor Configuration](configuration/SENSOR-CONFIGURATION.md)
@@ -111,7 +112,7 @@ features:
 | skip_climate_styles      | Disable climate-based color coding & borders                                                   |
 | skip_entity_styles       | Disable card background styling based on main entity                                           |
 | skip_mold_styles         | Disable mold indicator animations (reduces CPU usage on low-power devices)                     |
-| show_entity_labels       | Show entity labels under each entity icon                                                      |
+| show_entity_labels       | Show entity labels under each entity icon (labels support plain text and [Jinja](configuration/LABEL-TEMPLATES.md)) |
 | multi_light_background   | Enable background lighting when any light in the room is on                                    |
 | ignore_entity            | Ignore the custom entity configuration and use default room entity (useful with auto-entities) |
 | sticky_entities          | Keep entity positions stable even when state is unavailable (prevents UI layout shifts)        |

--- a/docs/configuration/BADGE-CONFIGURATION.md
+++ b/docs/configuration/BADGE-CONFIGURATION.md
@@ -1,6 +1,6 @@
 # Badge Configuration
 
-Badges are small overlay icons that appear on entity icons to provide additional visual information. Each entity can have up to 4 badges configured, positioned at the corners of the entity icon.
+Badges are small overlays that appear on entity icons to provide additional visual information. Each entity can have up to 4 badges configured, positioned at the corners of the entity icon.
 
 ![Entity Badges](../assets/badges.png)
 
@@ -10,6 +10,7 @@ Badges allow you to display:
 
 - Entity state icons (`ha-state-icon`) - automatically shows the state of an entity
 - Custom icons (`ha-icon`) - displays a specific icon based on state matching
+- Short text labels - fixed text or Home Assistant Jinja templates
 - Multiple badges per entity - up to 4 badges can be configured
 - Flexible positioning - badges can be placed at any corner of the entity icon
 
@@ -24,17 +25,18 @@ entities:
       - position: top_right
         mode: show_always
       - position: bottom_left
-        mode: if_active
+        mode: if_match
 ```
 
 ## Badge Configuration Options
 
-| Name      | Type   | Default     | Description                                                                                                                                                     |
-| --------- | ------ | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| entity_id | string | parent      | Optional entity ID for the badge (defaults to parent entity)                                                                                                    |
-| position  | string | `top_right` | Badge position: `top_right`, `top_left`, `bottom_right`, or `bottom_left`                                                                                       |
-| mode      | string | none        | Display mode: `show_always` (always show), `if_active` (show when entity is active), or `homeassistant` (use HA's native badge rendering for supported domains) |
-| states    | array  | none        | State-based configuration (when mode is not specified) - uses same format as entity `states`                                                                    |
+| Name      | Type   | Default     | Description                                                                                                                                                              |
+| --------- | ------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| entity_id | string | parent      | Optional entity ID for the badge (defaults to parent entity)                                                                                                             |
+| label     | string | none        | Optional text to show instead of an icon. Supports plain text or [Jinja templates](LABEL-TEMPLATES.md)                                                                   |
+| position  | string | `top_right` | Badge position: `top_right`, `top_left`, `bottom_right`, or `bottom_left`                                                                                                |
+| mode      | string | none        | Display mode: `show_always` (always show), `if_match` (show when a configured state matches), or `homeassistant` (use HA's native badge rendering for supported domains) |
+| states    | array  | none        | State-based configuration (when mode is not specified) - uses same format as entity `states`                                                                             |
 
 ### Position Options
 
@@ -61,19 +63,23 @@ entities:
 
 This badge will always be visible and will display the current state of `light.living_room` using Home Assistant's state icon.
 
-### If Active Mode
+### If Match Mode
 
-The `if_active` mode displays the badge only when the entity is considered "active" (on, open, playing, etc.):
+The `if_match` mode displays the badge only when one of the configured badge states matches:
 
 ```yaml
 entities:
   - entity_id: switch.living_room_fan
     badges:
       - position: top_right
-        mode: if_active
+        mode: if_match
+        states:
+          - state: 'on'
+            icon: mdi:fan
+            icon_color: blue
 ```
 
-This badge will only appear when the switch is on, and will display the active state icon.
+This badge will only appear when the switch is on, and will display the matching state icon or label.
 
 ### Home Assistant Mode
 
@@ -152,18 +158,53 @@ entities:
 
 This is useful when you want to show related entity information on a main entity icon.
 
+## Badge Text
+
+Use `label` when you want a badge to show short text instead of an icon. The label can be fixed text or a Home Assistant Jinja template:
+
+```yaml
+entities:
+  - entity_id: light.living_room
+    badges:
+      - entity_id: sensor.living_room_temperature
+        position: top_right
+        mode: show_always
+        label: "{{ states('sensor.living_room_temperature') | round(0) }}F"
+      - entity_id: sensor.living_room_humidity
+        position: bottom_right
+        mode: show_always
+        label: "{{ states('sensor.living_room_humidity') | int }}%"
+```
+
+State-based badges can also use `label`. When a state row matches, its `label` overrides the top-level badge `label`:
+
+```yaml
+entities:
+  - entity_id: binary_sensor.window
+    badges:
+      - position: top_right
+        label: OK
+        states:
+          - state: 'on'
+            icon_color: orange
+            label: Open
+```
+
+Keep badge text short, ideally 2-4 characters, because it overlays the corner of the entity icon. `mode: homeassistant` uses Home Assistant's native tile badge rendering and does not use custom badge text.
+
 ## State Configuration
 
 When using state-based badges (no `mode` specified), the `states` array uses the same configuration format as entity `states`:
 
-| Name       | Type   | Default      | Description                                              |
-| ---------- | ------ | ------------ | -------------------------------------------------------- |
-| state      | string | **Required** | Entity state or attribute value to match exactly         |
-| operator   | string | `eq`         | Comparison operator: `eq` (equal) or `ne` (not equal)    |
-| icon_color | string | **Required** | Color to use when this state is active                   |
-| icon       | string | none         | Icon to use when this state is active                    |
-| attribute  | string | none         | Optional attribute name to match instead of entity state |
-| styles     | object | none         | Custom CSS styles to apply to the badge icon             |
+| Name       | Type   | Default      | Description                                                                                        |
+| ---------- | ------ | ------------ | -------------------------------------------------------------------------------------------------- |
+| state      | string | **Required** | Entity state or attribute value to match exactly                                                   |
+| operator   | string | `eq`         | Comparison operator: `eq` (equal) or `ne` (not equal)                                              |
+| icon_color | string | **Required** | Color to use when this state is active                                                             |
+| icon       | string | none         | Icon to use when this state is active                                                              |
+| label      | string | none         | Text to show when this state matches. Supports plain text or [Jinja templates](LABEL-TEMPLATES.md) |
+| attribute  | string | none         | Optional attribute name to match instead of entity state                                           |
+| styles     | object | none         | Custom CSS styles to apply to the badge icon                                                       |
 
 ### State-Based Badge Examples
 
@@ -228,9 +269,13 @@ entities:
       # Always show entity state
       - position: top_right
         mode: show_always
-      # Show when active
+      # Show when matching a configured state
       - position: top_left
-        mode: if_active
+        mode: if_match
+        states:
+          - state: 'on'
+            icon: mdi:lightbulb-on
+            icon_color: yellow
       # Show brightness level badge
       - position: bottom_right
         states:
@@ -350,9 +395,9 @@ entities:
       # Always show state
       - position: top_right
         mode: show_always
-      # Show brightness indicator when active
+      # Show brightness indicator when matching a configured state
       - position: top_left
-        mode: if_active
+        mode: if_match
         states:
           - state: '255'
             attribute: brightness
@@ -390,7 +435,7 @@ entities:
 ## Best Practices
 
 1. **Limit badges**: While up to 4 badges are supported, use them sparingly to avoid cluttering the interface
-2. **Use modes when possible**: `show_always`, `if_active`, and `homeassistant` modes are simpler than state-based configuration
+2. **Use modes when possible**: `show_always`, `if_match`, and `homeassistant` modes are simpler than state-based configuration
 3. **Use `homeassistant` mode for supported domains**: For `person`, `device_tracker`, `climate`, and `humidifier` entities, use `homeassistant` mode to get native Home Assistant badge rendering
 4. **Position strategically**: Place the most important badge at `top_right` (most visible)
 5. **Use related entities**: Badges are great for showing related sensor data on main entity icons

--- a/docs/configuration/ENTITY-COLOR-CONFIGURATION.md
+++ b/docs/configuration/ENTITY-COLOR-CONFIGURATION.md
@@ -54,7 +54,7 @@ entities:
 
 ### 3. State-Based Colors and Icons
 
-Configure colors, icons, and labels that match exact entity states (perfect for non-numeric sensors):
+Configure colors, icons, and labels that match exact entity states (perfect for non-numeric sensors). Each row’s `label` may be plain text or a [Jinja template](LABEL-TEMPLATES.md):
 
 ```yaml
 entities:
@@ -150,7 +150,7 @@ The `styles` property accepts any CSS property-value pairs and applies them dire
 
 ![Thresholds](../assets/thresholds.gif)
 
-Configure dynamic colors, icons, and labels based on numeric sensor values:
+Configure dynamic colors, icons, and labels based on numeric sensor values. Threshold `label` fields also support [Jinja templates](LABEL-TEMPLATES.md):
 
 ```yaml
 entities:

--- a/docs/configuration/ENTITY-CONFIGURATION.md
+++ b/docs/configuration/ENTITY-CONFIGURATION.md
@@ -30,48 +30,48 @@ entities:
 
 ## Entity Configuration Options
 
-| Name              | Type                      | Default                 | Description                                                                                           |
-| ----------------- | ------------------------- | ----------------------- | ----------------------------------------------------------------------------------------------------- |
-| entity_id         | string                    | **Required**            | Entity ID in Home Assistant                                                                           |
-| icon              | string                    | entity default          | Custom MDI icon                                                                                       |
-| label             | string                    | none                    | Custom label to display instead of entity name (when `show_entity_labels` is enabled) or sensor state |
-| attribute         | string or list of strings | none                    | Attribute(s) to show instead of entity state                                                          |
-| on_color          | string                    | domain default          | Color when entity is active                                                                           |
-| off_color         | string                    | theme off color         | Color when entity is inactive                                                                         |
-| thresholds        | array                     | none                    | Dynamic colors/icons based on sensor values                                                           |
-| states            | array                     | none                    | Colors/icons based on exact entity states                                                             |
-| badges            | array                     | none                    | Badge overlays for additional visual information (up to 4 badges per entity)                          |
-| styles            | object                    | none                    | Custom CSS styles to apply to the entity                                                              |
-| features          | array                     | none                    | Feature flags for this entity                                                                         |
-| tap_action        | object                    | `{action: "toggle"}`    | Action on single tap                                                                                  |
-| hold_action       | object                    | `{action: "more-info"}` | Action on hold                                                                                        |
-| double_tap_action | object                    | `{action: "none"}`      | Action on double tap                                                                                  |
+| Name              | Type                      | Default                 | Description                                                                             |
+| ----------------- | ------------------------- | ----------------------- | --------------------------------------------------------------------------------------- |
+| entity_id         | string                    | **Required**            | Entity ID in Home Assistant                                                             |
+| icon              | string                    | entity default          | Custom MDI icon                                                                         |
+| label             | string                    | none                    | Label under the icon or for sensors: plain text or [Jinja template](LABEL-TEMPLATES.md) |
+| attribute         | string or list of strings | none                    | Attribute(s) to show instead of entity state                                            |
+| on_color          | string                    | domain default          | Color when entity is active                                                             |
+| off_color         | string                    | theme off color         | Color when entity is inactive                                                           |
+| thresholds        | array                     | none                    | Dynamic colors/icons based on sensor values                                             |
+| states            | array                     | none                    | Colors/icons based on exact entity states                                               |
+| badges            | array                     | none                    | Badge overlays for additional visual information (up to 4 badges per entity)            |
+| styles            | object                    | none                    | Custom CSS styles to apply to the entity                                                |
+| features          | array                     | none                    | Feature flags for this entity                                                           |
+| tap_action        | object                    | `{action: "toggle"}`    | Action on single tap                                                                    |
+| hold_action       | object                    | `{action: "more-info"}` | Action on hold                                                                          |
+| double_tap_action | object                    | `{action: "none"}`      | Action on double tap                                                                    |
 
 ### Threshold Configuration Options
 
-| Name        | Type   | Default      | Description                                                                        |
-| ----------- | ------ | ------------ | ---------------------------------------------------------------------------------- |
-| threshold   | number | **Required** | Threshold value to compare against entity state or attribute                       |
-| icon_color  | string | **Required** | Color to use when this threshold condition is met                                  |
-| title_color | string | none         | Color to use for the card title when this threshold condition is met               |
-| icon        | string | none         | Icon to use when this threshold condition is met                                   |
-| label       | string | none         | Custom label to display when this threshold matches (overrides entity-level label) |
-| operator    | string | `gte`        | Comparison operator: `gt`, `gte`, `lt`, `lte`, `eq`                                |
-| attribute   | string | none         | Optional attribute name to compare instead of entity state                         |
-| styles      | object | none         | Custom CSS styles to apply to entity icon                                          |
+| Name        | Type   | Default      | Description                                                                                                   |
+| ----------- | ------ | ------------ | ------------------------------------------------------------------------------------------------------------- |
+| threshold   | number | **Required** | Threshold value to compare against entity state or attribute                                                  |
+| icon_color  | string | **Required** | Color to use when this threshold condition is met                                                             |
+| title_color | string | none         | Color to use for the card title when this threshold condition is met                                          |
+| icon        | string | none         | Icon to use when this threshold condition is met                                                              |
+| label       | string | none         | Label when this threshold matches (plain text or [Jinja](LABEL-TEMPLATES.md); overrides entity-level `label`) |
+| operator    | string | `gte`        | Comparison operator: `gt`, `gte`, `lt`, `lte`, `eq`                                                           |
+| attribute   | string | none         | Optional attribute name to compare instead of entity state                                                    |
+| styles      | object | none         | Custom CSS styles to apply to entity icon                                                                     |
 
 ### State Configuration Options
 
-| Name        | Type   | Default      | Description                                                                    |
-| ----------- | ------ | ------------ | ------------------------------------------------------------------------------ |
-| state       | string | **Required** | Entity state or attribute value to match exactly                               |
-| operator    | string | `eq`         | Comparison operator: `eq` (equal) or `ne` (not equal)                          |
-| icon_color  | string | **Required** | Color to use when this state is active                                         |
-| title_color | string | none         | Color to use for the card title when this state is active                      |
-| icon        | string | none         | Icon to use when this state is active                                          |
-| label       | string | none         | Custom label to display when this state matches (overrides entity-level label) |
-| attribute   | string | none         | Optional attribute name to match instead of entity state                       |
-| styles      | object | none         | Custom CSS styles to apply to entity icon                                      |
+| Name        | Type   | Default      | Description                                                                                               |
+| ----------- | ------ | ------------ | --------------------------------------------------------------------------------------------------------- |
+| state       | string | **Required** | Entity state or attribute value to match exactly                                                          |
+| operator    | string | `eq`         | Comparison operator: `eq` (equal) or `ne` (not equal)                                                     |
+| icon_color  | string | **Required** | Color to use when this state is active                                                                    |
+| title_color | string | none         | Color to use for the card title when this state is active                                                 |
+| icon        | string | none         | Icon to use when this state is active                                                                     |
+| label       | string | none         | Label when this state matches (plain text or [Jinja](LABEL-TEMPLATES.md); overrides entity-level `label`) |
+| attribute   | string | none         | Optional attribute name to match instead of entity state                                                  |
+| styles      | object | none         | Custom CSS styles to apply to entity icon                                                                 |
 
 ### Badge Configuration
 
@@ -465,6 +465,8 @@ The `show_entity_labels` feature flag displays labels under each entity icon. La
 3. **Attribute value(s)** - Displayed when an `attribute` property is configured (replaces entity name/label). Use a string for one attribute or a list for multiple.
 4. **Entity name** (fallback) - Displayed when no label or attribute is configured (uses Home Assistant's entity naming logic)
 
+📖 **Jinja templates:** Any of the `label` fields above—including on `states` and `thresholds` rows—can use [Home Assistant Jinja2](https://www.home-assistant.io/docs/configuration/templating/) when the string contains `{{` or `{%`. See **[Label templates (Jinja)](LABEL-TEMPLATES.md)** for examples (related sensors, threshold captions, and editor notes).
+
 ### Label Priority Examples
 
 ```yaml
@@ -554,4 +556,6 @@ sensors:
       - state
 ```
 
-**Note**: When labels are configured for sensors, they replace the sensor's state display. When an `attribute` is specified (string or list), it displays the formatted attribute value(s) instead of the state. When labels are not configured, sensors display their normal state values (e.g., "75°F", "50%", "450 ppm").
+**Note**: When labels are configured for sensors, they replace the sensor's state display. When an `attribute` is specified (string or list), it displays the formatted attribute value(s) instead of the state. When labels are not configured, sensors display their normal state values (e.g., "75°F", "50%", "450 ppm"). Sensor `label` values support the same [Jinja templates](LABEL-TEMPLATES.md) as entity labels.
+
+📖 **See also:** [Sensor configuration — labels](SENSOR-CONFIGURATION.md#labels-for-sensors) and [Label templates (Jinja)](LABEL-TEMPLATES.md).

--- a/docs/configuration/EXAMPLES.md
+++ b/docs/configuration/EXAMPLES.md
@@ -500,6 +500,33 @@ styles:
 
 This example shows entity labels with custom icon styling and opacity levels.
 
+### Entity and sensor labels with Jinja templates
+
+Show live values from other entities under icons or in the sensor row. Requires `show_entity_labels` for icon labels. See **[Label templates (Jinja)](LABEL-TEMPLATES.md)** and the [Home Assistant templating docs](https://www.home-assistant.io/docs/configuration/templating/).
+
+```yaml
+type: custom:room-summary-card
+area: bedroom
+features:
+  - show_entity_labels
+entities:
+  - entity_id: light.bedroom
+    label: "{{ states('sensor.bedroom_temperature') | round(1) }}°"
+  - entity_id: sensor.washing_machine_state
+    states:
+      - state: running
+        label: Running
+      - state: finished
+        label: "{{ states('sensor.bedroom_humidity') | int }}% RH"
+sensors:
+  - entity_id: sensor.bedroom_temperature
+    thresholds:
+      - threshold: 75
+        operator: gte
+        icon_color: red
+        label: "Hot {{ states('sensor.bedroom_temperature') | round(0) }}°"
+```
+
 ### Problem Entities Setup
 
 To use problem detection, label entities with "problem":

--- a/docs/configuration/LABEL-TEMPLATES.md
+++ b/docs/configuration/LABEL-TEMPLATES.md
@@ -1,0 +1,108 @@
+# Label templates (Jinja)
+
+Entity icons and climate sensors can show a **label** under (or beside) the icon. Labels are usually plain text, but any `label` field—including on **entities**, **sensors**, **states**, and **thresholds**—can use [Home Assistant Jinja2 templates](https://www.home-assistant.io/docs/configuration/templating/) when the value contains `{{` or `{%`.
+
+The card evaluates templates on the server via the `render_template` websocket API and updates the label when referenced entities or time change.
+
+## Where templates work
+
+| Location | YAML path | When it is shown |
+| -------- | --------- | ---------------- |
+| Entity icon | `entities[].label` | `show_entity_labels` is enabled |
+| Sensor row | `sensors[].label` | Sensor labels are not hidden (`hide_sensor_labels` off) |
+| State match | `entities[].states[].label` or `sensors[].states[].label` | When that state row matches |
+| Threshold match | `entities[].thresholds[].label` or `sensors[].thresholds[].label` | When that threshold row matches |
+
+**Priority** (same as static labels):
+
+1. Matching **state** or **threshold** `label` (highest)
+2. Entity/sensor **`label`**
+3. **`attribute`** display (if configured)
+4. **Entity name** (icons only) or **formatted state** (sensors)
+
+If the winning label contains template syntax, it is rendered as Jinja; otherwise it is shown as plain text.
+
+## Plain text (no template)
+
+You do not need special syntax for a fixed caption:
+
+```yaml
+entities:
+  - entity_id: light.kitchen
+    label: Kitchen
+```
+
+## Entity label from another sensor
+
+Show a related value under a light or switch (requires `show_entity_labels`):
+
+```yaml
+type: custom:room-summary-card
+area: bedroom
+features:
+  - show_entity_labels
+entities:
+  - entity_id: light.bedroom
+    label: "{{ states('sensor.bedroom_temperature') | round(1) }}°"
+```
+
+## Sensor label with template
+
+Templates replace the sensor’s normal state text when they win the label priority:
+
+```yaml
+sensors:
+  - entity_id: sensor.bedroom_temperature
+    label: "{{ states('sensor.bedroom_humidity') | int }}% RH"
+```
+
+## State-based template label
+
+Use a different template per state (icons or sensors):
+
+```yaml
+entities:
+  - entity_id: binary_sensor.window
+    label: Window
+    states:
+      - state: 'on'
+        icon_color: orange
+        label: "Open · {{ states('sensor.outdoor_temperature') }}°"
+      - state: 'off'
+        icon_color: green
+        label: Closed
+```
+
+## Threshold-based template label
+
+Numeric thresholds can also use templates for the label that appears when the row matches:
+
+```yaml
+entities:
+  - entity_id: sensor.living_room_temperature
+    label: Temp
+    thresholds:
+      - threshold: 75
+        operator: gte
+        icon_color: red
+        label: "Hot {{ states('sensor.living_room_temperature') | round(0) }}°"
+      - threshold: 60
+        operator: gte
+        icon_color: green
+        label: "OK {{ states('sensor.living_room_temperature') | round(0) }}°"
+```
+
+## Tips
+
+- **Detection**: Only strings containing `{{` or `{%` are sent to the template engine. Plain text is never parsed as Jinja.
+- **Context**: Templates use the row’s `entity_id` as template context (same as many HA cards).
+- **Editor**: In the UI editor, the label field uses the template selector with optional preview.
+- **Performance**: Each templated label holds one `render_template` subscription. Use templates where they add value; static labels are cheaper.
+- **Errors**: Invalid templates are logged in the browser console; the label may stay empty until the template is fixed.
+
+## Related documentation
+
+- [Entity labels](ENTITY-CONFIGURATION.md#entity-labels) — feature flag, priority, attributes
+- [Sensor labels](SENSOR-CONFIGURATION.md#labels-for-sensors) — sensor-specific behavior
+- [State-based styling](ENTITY-COLOR-CONFIGURATION.md#3-state-based-colors-and-icons) — colors, icons, and labels per state
+- [Threshold styling](ENTITY-COLOR-CONFIGURATION.md#4-threshold-based-colors-and-icons) — numeric thresholds and labels

--- a/docs/configuration/LABEL-TEMPLATES.md
+++ b/docs/configuration/LABEL-TEMPLATES.md
@@ -1,17 +1,19 @@
 # Label templates (Jinja)
 
-Entity icons and climate sensors can show a **label** under (or beside) the icon. Labels are usually plain text, but any `label` field—including on **entities**, **sensors**, **states**, and **thresholds**—can use [Home Assistant Jinja2 templates](https://www.home-assistant.io/docs/configuration/templating/) when the value contains `{{` or `{%`.
+Entity icons, climate sensors, and badges can show a **label**. Labels are usually plain text, but any `label` field—including on **entities**, **sensors**, **badges**, **states**, and **thresholds**—can use [Home Assistant Jinja2 templates](https://www.home-assistant.io/docs/configuration/templating/) when the value contains `{{` or `{%`.
 
 The card evaluates templates on the server via the `render_template` websocket API and updates the label when referenced entities or time change.
 
 ## Where templates work
 
-| Location | YAML path | When it is shown |
-| -------- | --------- | ---------------- |
-| Entity icon | `entities[].label` | `show_entity_labels` is enabled |
-| Sensor row | `sensors[].label` | Sensor labels are not hidden (`hide_sensor_labels` off) |
-| State match | `entities[].states[].label` or `sensors[].states[].label` | When that state row matches |
-| Threshold match | `entities[].thresholds[].label` or `sensors[].thresholds[].label` | When that threshold row matches |
+| Location          | YAML path                                                         | When it is shown                                        |
+| ----------------- | ----------------------------------------------------------------- | ------------------------------------------------------- |
+| Entity icon       | `entities[].label`                                                | `show_entity_labels` is enabled                         |
+| Sensor row        | `sensors[].label`                                                 | Sensor labels are not hidden (`hide_sensor_labels` off) |
+| Badge             | `entities[].badges[].label`                                       | When the badge is shown                                 |
+| Badge state match | `entities[].badges[].states[].label`                              | When that badge state row matches                       |
+| State match       | `entities[].states[].label` or `sensors[].states[].label`         | When that state row matches                             |
+| Threshold match   | `entities[].thresholds[].label` or `sensors[].thresholds[].label` | When that threshold row matches                         |
 
 **Priority** (same as static labels):
 
@@ -21,6 +23,8 @@ The card evaluates templates on the server via the `render_template` websocket A
 4. **Entity name** (icons only) or **formatted state** (sensors)
 
 If the winning label contains template syntax, it is rendered as Jinja; otherwise it is shown as plain text.
+
+Badge labels use a similar priority inside the badge: matching badge state `label`, then the badge-level `label`, then the normal badge icon.
 
 ## Plain text (no template)
 
@@ -55,6 +59,22 @@ sensors:
   - entity_id: sensor.bedroom_temperature
     label: "{{ states('sensor.bedroom_humidity') | int }}% RH"
 ```
+
+## Badge label with template
+
+Show a short related value directly on an entity badge:
+
+```yaml
+entities:
+  - entity_id: light.bedroom
+    badges:
+      - entity_id: sensor.bedroom_temperature
+        position: top_right
+        mode: show_always
+        label: "{{ states('sensor.bedroom_temperature') | round(0) }}°"
+```
+
+Keep badge labels short because they sit over a corner of the entity icon.
 
 ## State-based template label
 
@@ -96,6 +116,7 @@ entities:
 
 - **Detection**: Only strings containing `{{` or `{%` are sent to the template engine. Plain text is never parsed as Jinja.
 - **Context**: Templates use the row’s `entity_id` as template context (same as many HA cards).
+- **Badges**: Badge templates use the badge entity, which defaults to the parent entity unless `badges[].entity_id` is set.
 - **Editor**: In the UI editor, the label field uses the template selector with optional preview.
 - **Performance**: Each templated label holds one `render_template` subscription. Use templates where they add value; static labels are cheaper.
 - **Errors**: Invalid templates are logged in the browser console; the label may stay empty until the template is fixed.
@@ -104,5 +125,6 @@ entities:
 
 - [Entity labels](ENTITY-CONFIGURATION.md#entity-labels) — feature flag, priority, attributes
 - [Sensor labels](SENSOR-CONFIGURATION.md#labels-for-sensors) — sensor-specific behavior
+- [Badge labels](BADGE-CONFIGURATION.md#badge-text) — text badges and template examples
 - [State-based styling](ENTITY-COLOR-CONFIGURATION.md#3-state-based-colors-and-icons) — colors, icons, and labels per state
 - [Threshold styling](ENTITY-COLOR-CONFIGURATION.md#4-threshold-based-colors-and-icons) — numeric thresholds and labels

--- a/docs/configuration/SENSOR-CONFIGURATION.md
+++ b/docs/configuration/SENSOR-CONFIGURATION.md
@@ -40,7 +40,7 @@ State-based icons take priority over the configured icon, which serves as a fall
 
 #### Object Format with State-Based Styling and Labels
 
-You can configure sensors with state-based styling and custom labels, similar to entity configuration:
+You can configure sensors with state-based styling and custom labels, similar to entity configuration. Labels may be **plain text** or **[Jinja templates](LABEL-TEMPLATES.md)**:
 
 ```yaml
 sensors:
@@ -188,9 +188,11 @@ When the sensor state matches a configured state, the card will:
 Sensors can have custom labels configured at multiple levels:
 
 1. **State label** (highest priority) - Displayed when a matching state configuration has a `label` property
-2. **Entity-level label** - Displayed when the sensor has a `label` property configured
+2. **Sensor `label`** - Displayed when the sensor entry has a `label` property configured
 3. **Attribute value(s)** - Displayed when an `attribute` property is configured (replaces state display); use a string or list of strings
 4. **Sensor state value** (fallback) - Displayed when no label or attribute is configured (e.g., "75°F", "50%", "450 ppm")
+
+📖 **Jinja templates:** `label` on the sensor, or on a matching `states` / `thresholds` row, can use [Home Assistant Jinja2](https://www.home-assistant.io/docs/configuration/templating/). See **[Label templates (Jinja)](LABEL-TEMPLATES.md)** for examples.
 
 ```yaml
 sensors:
@@ -230,6 +232,13 @@ sensors:
 ```
 
 **Note**: When labels are configured for sensors, they replace the sensor's state display. When an `attribute` is specified (string or list), it displays the formatted attribute value(s) instead of the state. When labels are not configured, sensors display their normal state values.
+
+```yaml
+# Template label: show outdoor temp next to indoor sensor
+sensors:
+  - entity_id: sensor.living_room_temperature
+    label: "{{ states('sensor.outdoor_temperature') | round(0) }}° out"
+```
 
 #### Icon Priority
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -129,6 +129,16 @@ Small overlay icons that appear on entity icons to provide additional visual inf
 
 📖 **See [Badge Configuration](configuration/BADGE-CONFIGURATION.md) for complete documentation.**
 
+### Entity and sensor labels
+
+Optional captions under entity icons (`show_entity_labels`) or beside climate sensors:
+
+- **Plain text** — fixed captions such as `Kitchen` or `Door`
+- **Jinja templates** — any `label` on entities, sensors, **states**, or **thresholds** (e.g. show another sensor’s temperature under a light)
+- **Priority** — state/threshold label → entity/sensor `label` → attribute → name or formatted state
+
+📖 **See [Label templates (Jinja)](configuration/LABEL-TEMPLATES.md)** · [Entity labels](configuration/ENTITY-CONFIGURATION.md#entity-labels) · [Sensor labels](configuration/SENSOR-CONFIGURATION.md#labels-for-sensors)
+
 ### Problem Detection
 
 - Automatically detects entities labeled as "problem" in the area
@@ -316,6 +326,8 @@ The card automatically discovers and displays:
 📚 **Detailed Documentation:**
 
 - **[Configuration Guide](CONFIGURATION.md)** - Complete configuration options and examples
+- **[Label templates (Jinja)](configuration/LABEL-TEMPLATES.md)** - Dynamic entity and sensor labels with Home Assistant templates
+- **[Release notes](RELEASE_NOTES.md)** - What’s new (e.g. label templates)
 - **[Theming Guide](THEMING.md)** - Theme support and color customization
 - **[Advanced Usage](ADVANCED.md)** - Advanced features and entity attributes
 - **[Troubleshooting](TROUBLESHOOTING.md)** - Common issues and solutions

--- a/docs/trouble/PERFORMANCE-ISSUES.md
+++ b/docs/trouble/PERFORMANCE-ISSUES.md
@@ -32,6 +32,7 @@
 1. **Check sensor update frequency**: Reduce polling frequency
 2. **Use template sensors**: Aggregate data before display
 3. **Limit real-time sensors**: Use static data where possible
+4. **Label templates**: Each templated `label` uses a `render_template` subscription; prefer static text where you do not need live data. See [Label templates](../configuration/LABEL-TEMPLATES.md).
 
 ### Memory Issues
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "parcel": "^2.16.4",
     "prettier": "3.8.3",
     "prettier-plugin-organize-imports": "^4.3.0",
-    "sinon": "^21.1.2",
+    "sinon": "^22.0.0",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^6.0.3"

--- a/src/cards/components/badge/badge-label.ts
+++ b/src/cards/components/badge/badge-label.ts
@@ -1,0 +1,57 @@
+import { HassConfigMixin } from '@cards/mixins/hass-config-mixin';
+import { LabelTemplateConnection } from '@delegates/label-template-connection';
+import { isTemplateString } from '@hass/common/string/is_template';
+import { css, html, LitElement, nothing, type TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+/**
+ * Text content inside a badge. Handles static labels and live Jinja templates.
+ */
+@customElement('room-badge-label')
+export class RoomBadgeLabel extends HassConfigMixin(LitElement) {
+  private readonly _labelTemplateConn = new LabelTemplateConnection(() =>
+    this.requestUpdate(),
+  );
+
+  public entityId = '';
+
+  public label?: string;
+
+  static override readonly styles = css`
+    :host {
+      display: inline-flex;
+      justify-content: center;
+      padding: 0 2px;
+      overflow: hidden;
+      font-size: 0.65rem;
+      line-height: 1;
+      white-space: nowrap;
+    }
+  `;
+
+  override disconnectedCallback(): void {
+    this._labelTemplateConn.disconnect();
+    super.disconnectedCallback();
+  }
+
+  override render(): TemplateResult | typeof nothing {
+    if (!this.label) {
+      this._labelTemplateConn.disconnect();
+      return nothing;
+    }
+
+    if (isTemplateString(this.label)) {
+      this._labelTemplateConn.sync(this.hass, this.entityId, this.label);
+      return html`${this._labelTemplateConn.displayedText}`;
+    }
+
+    this._labelTemplateConn.disconnect();
+    return html`${this.label}`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'room-badge-label': RoomBadgeLabel;
+  }
+}

--- a/src/cards/components/badge/badge.ts
+++ b/src/cards/components/badge/badge.ts
@@ -16,6 +16,7 @@ import {
 } from 'lit';
 import { property } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
+import './badge-label';
 import { styles } from './styles';
 const equal = require('fast-deep-equal');
 
@@ -23,7 +24,8 @@ const equal = require('fast-deep-equal');
  * Badge Component
  *
  * A small Lit element that renders a badge overlay for an entity.
- * Badges can display entity state icons or custom icons based on configuration.
+ * Badges can display entity state icons, custom icons, or short text based on
+ * configuration.
  */
 export class Badge extends SubscribeEntityStateMixin(
   HassUpdateMixin(LitElement),
@@ -91,6 +93,8 @@ export class Badge extends SubscribeEntityStateMixin(
       return nothing;
     }
 
+    const label = matchingState?.label ?? badge.label;
+
     return html`
       ${matchingState?.styles ? stylesToHostCss(matchingState.styles) : nothing}
       <ha-tile-badge
@@ -100,11 +104,21 @@ export class Badge extends SubscribeEntityStateMixin(
           ),
         })}
       >
-        <ha-state-icon
-          .hass=${hass}
-          .stateObj=${state}
-          .icon=${matchingState?.icon}
-        ></ha-state-icon>
+        ${label
+          ? html`
+              <room-badge-label
+                .hass=${hass}
+                .entityId=${id ?? ''}
+                .label=${label}
+              ></room-badge-label>
+            `
+          : html`
+              <ha-state-icon
+                .hass=${hass}
+                .stateObj=${state}
+                .icon=${matchingState?.icon}
+              ></ha-state-icon>
+            `}
       </ha-tile-badge>
     `;
   }

--- a/src/cards/components/editor/entity-detail-editor.ts
+++ b/src/cards/components/editor/entity-detail-editor.ts
@@ -61,23 +61,16 @@ export class RoomSummaryEntityDetailEditor extends LitElement {
           selector: { entity: {} },
         },
         {
-          type: 'grid',
-          name: '',
+          name: 'icon',
+          label: 'editor.entity.entity_icon',
+          selector: {
+            icon: {},
+          },
+        },
+        {
+          name: 'label',
           label: 'editor.entity.entity_label',
-          schema: [
-            {
-              name: 'label',
-              label: 'editor.entity.entity_label',
-              selector: { text: {} },
-            },
-            {
-              name: 'icon',
-              label: 'editor.entity.entity_icon',
-              selector: {
-                icon: {},
-              },
-            },
-          ],
+          selector: { template: { preview: true } },
         },
         {
           name: 'attribute',
@@ -238,23 +231,16 @@ export class RoomSummaryEntityDetailEditor extends LitElement {
           selector: { entity: {} },
         },
         {
-          type: 'grid',
-          name: '',
+          name: 'icon',
+          label: 'editor.entity.entity_icon',
+          selector: {
+            icon: {},
+          },
+        },
+        {
+          name: 'label',
           label: 'editor.entity.entity_label',
-          schema: [
-            {
-              name: 'label',
-              label: 'editor.entity.entity_label',
-              selector: { text: {} },
-            },
-            {
-              name: 'icon',
-              label: 'editor.entity.entity_icon',
-              selector: {
-                icon: {},
-              },
-            },
-          ],
+          selector: { template: { preview: true } },
         },
         {
           name: 'attribute',

--- a/src/cards/components/editor/states-row-editor.ts
+++ b/src/cards/components/editor/states-row-editor.ts
@@ -1,5 +1,6 @@
 import { ensureArray } from '@hass/common/array/ensure-array';
 import { fireEvent } from '@hass/common/dom/fire_event';
+import { isTemplateString } from '@hass/common/string/is_template';
 import type { HaFormSchema } from '@hass/components/ha-form/types';
 import type { HomeAssistant } from '@hass/types';
 import { localize } from '@localize/localize';
@@ -106,23 +107,15 @@ export class RoomSummaryStatesRowEditor extends LitElement {
 
       schema.push(
         {
-          type: 'grid',
-          name: '',
-          label: 'editor.entity.entity_label',
-          schema: [
-            {
-              name: 'icon',
-              label: 'editor.entity.state.icon',
-              required: false,
-              selector: { icon: {} },
-            },
-            {
-              name: 'label',
-              label: 'editor.entity.state.label',
-              required: false,
-              selector: { text: {} },
-            },
-          ],
+          name: 'icon',
+          label: 'editor.entity.state.icon',
+          required: false,
+          selector: { icon: {} },
+        },
+        {
+          name: 'label',
+          label: 'editor.entity.state.label',
+          selector: { template: { preview: true } },
         },
         {
           name: 'attribute',
@@ -217,23 +210,15 @@ export class RoomSummaryStatesRowEditor extends LitElement {
           },
         },
         {
-          type: 'grid',
-          name: '',
-          label: 'editor.entity.entity_label',
-          schema: [
-            {
-              name: 'icon',
-              label: 'editor.entity.threshold.icon',
-              required: false,
-              selector: { icon: {} },
-            },
-            {
-              name: 'label',
-              label: 'editor.entity.threshold.label',
-              required: false,
-              selector: { text: {} },
-            },
-          ],
+          name: 'icon',
+          label: 'editor.entity.threshold.icon',
+          required: false,
+          selector: { icon: {} },
+        },
+        {
+          name: 'label',
+          label: 'editor.entity.threshold.label',
+          selector: { template: { preview: true } },
         },
         {
           name: 'attribute',
@@ -390,13 +375,13 @@ export class RoomSummaryStatesRowEditor extends LitElement {
   private _getItemTitle(item: StateConfig | ThresholdConfig): string {
     if (this.mode === 'states') {
       const state = item as StateConfig;
-      if (state.label) {
+      if (state.label && !isTemplateString(state.label)) {
         return `${state.state} (${state.label})`;
       }
       return state.state || 'New State';
     } else {
       const threshold = item as ThresholdConfig;
-      if (threshold.label) {
+      if (threshold.label && !isTemplateString(threshold.label)) {
         return `${threshold.threshold} (${threshold.label})`;
       }
       return threshold.threshold?.toString() || 'New Threshold';

--- a/src/cards/components/editor/utils/badge-editor-schema.ts
+++ b/src/cards/components/editor/utils/badge-editor-schema.ts
@@ -16,6 +16,12 @@ export const getBadgeSchema = memoizeOne(
         selector: { entity: {} },
       },
       {
+        name: 'label',
+        required: false,
+        label: 'editor.badge.label',
+        selector: { template: { preview: true } },
+      },
+      {
         name: 'position',
         required: false,
         label: 'editor.badge.position_label',

--- a/src/cards/components/editor/utils/badge-editor-utils.ts
+++ b/src/cards/components/editor/utils/badge-editor-utils.ts
@@ -1,3 +1,4 @@
+import { isTemplateString } from '@hass/common/string/is_template';
 import type { BadgeConfig } from '@type/config/entity';
 
 /**
@@ -40,17 +41,26 @@ export function cleanEmptyStrings(obj: any): any {
  * Generates a display title for a badge based on its configuration
  */
 export function getBadgeTitle(badge: BadgeConfig): string {
+  let labelPreview = '';
+  if (badge.label && !isTemplateString(badge.label)) {
+    const shortLabel =
+      badge.label.length > 20 ? badge.label.slice(0, 20) + '...' : badge.label;
+    labelPreview = ` - ${shortLabel}`;
+  }
+
   if (badge.mode === 'show_always') {
-    return `Show Always (${badge.position || 'top_right'})`;
+    return `Show Always (${badge.position || 'top_right'})${labelPreview}`;
   }
   if (badge.mode === 'if_match') {
-    return `If Match (${badge.position || 'top_right'})`;
+    return `If Match (${badge.position || 'top_right'})${labelPreview}`;
   }
   if (badge.mode === 'homeassistant') {
     return `Home Assistant (${badge.position || 'top_right'})`;
   }
   if (badge.states && badge.states.length > 0) {
-    return `States (${badge.states.length}) - ${badge.position || 'top_right'}`;
+    return `States (${badge.states.length}) - ${
+      badge.position || 'top_right'
+    }${labelPreview}`;
   }
-  return `Badge ${badge.position || 'top_right'}`;
+  return `Badge ${badge.position || 'top_right'}${labelPreview}`;
 }

--- a/src/cards/components/room-state-icon/entity-label.ts
+++ b/src/cards/components/room-state-icon/entity-label.ts
@@ -1,0 +1,75 @@
+import { HassConfigMixin } from '@cards/mixins/hass-config-mixin';
+import { LabelTemplateConnection } from '@delegates/label-template-connection';
+import { renderConfiguredEntityLabel } from '@html/render-label';
+import type { EntityInformation } from '@type/room';
+import { CSSResult, LitElement, css, nothing, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+const equal = require('fast-deep-equal');
+
+/**
+ * Label under a room-state icon: state/threshold label, Jinja `label`, static
+ * text, attribute, or entity name.
+ */
+@customElement('room-entity-label')
+export class RoomEntityLabel extends HassConfigMixin(LitElement) {
+  private readonly _labelTemplateConn = new LabelTemplateConnection(() =>
+    this.requestUpdate(),
+  );
+
+  isMainRoomEntity = false;
+
+  get show(): boolean {
+    return (
+      (this.config?.features?.includes('show_entity_labels') ?? false) &&
+      !(
+        this.isMainRoomEntity &&
+        (this.config?.background?.options?.includes('hide_icon_only') ?? false)
+      )
+    );
+  }
+
+  @property({
+    type: Object,
+    hasChanged: (a: EntityInformation, b: EntityInformation) => !equal(a, b),
+  })
+  entity!: EntityInformation;
+
+  /**
+   * Returns the component's styles
+   */
+  static override get styles(): CSSResult {
+    return css`
+      :host {
+        position: absolute;
+        font-size: 0.7em;
+        text-align: center;
+        overflow: hidden;
+        margin-top: 75%;
+        display: var(--user-entity-label-display, block);
+      }
+    `;
+  }
+
+  override disconnectedCallback(): void {
+    this._labelTemplateConn.disconnect();
+    super.disconnectedCallback();
+  }
+
+  /**
+   * renders the lit element card
+   * @returns {TemplateResult} The rendered HTML template
+   */
+  override render(): TemplateResult | typeof nothing {
+    if (!this.show) {
+      this._labelTemplateConn.disconnect();
+      return nothing;
+    }
+
+    return renderConfiguredEntityLabel(
+      this.hass,
+      this.entity,
+      this._labelTemplateConn,
+      'entity-name',
+    );
+  }
+}

--- a/src/cards/components/room-state-icon/room-state-icon.ts
+++ b/src/cards/components/room-state-icon/room-state-icon.ts
@@ -4,20 +4,19 @@ import {
   actionHandler,
   handleClickAction,
 } from '@delegates/action-handler-delegate';
-import { computeEntityName } from '@hass/common/entity/compute_entity_name';
 import type { HomeAssistant } from '@hass/types';
 import { renderBadgeElements } from '@html/badge-squad';
 import { renderStateDisplay } from '@html/render-state-display';
-import { stateDisplay } from '@html/state-display';
 import { renderEntityIconStyles } from '@theme/render/icon-styles';
 import { computeEntityIcon } from '@theme/render/loot-box-icon';
-import { getEntityLabel, getThresholdResult } from '@theme/threshold-color';
+import { getThresholdResult } from '@theme/threshold-color';
 import { stylesToHostCss } from '@theme/util/style-converter';
 import type { Config } from '@type/config';
 import type { EntityInformation } from '@type/room';
 import { d } from '@util/debug';
 import { CSSResult, LitElement, html, nothing, type TemplateResult } from 'lit';
 import { property, state } from 'lit/decorators.js';
+import './entity-label';
 import { styles } from './styles';
 const equal = require('fast-deep-equal');
 
@@ -34,7 +33,6 @@ const equal = require('fast-deep-equal');
  * - Integration with Home Assistant state management
  * - Support for custom icon configuration
  * - Proper state display delegation to the icon rendering system
- * - Optional entity labels when show_entity_labels feature is enabled
  *
  * @version See package.json
  */
@@ -49,12 +47,6 @@ export class RoomStateIcon extends HassUpdateMixin(LitElement) {
    */
   @state()
   private _config!: Config;
-
-  /**
-   * Whether to show entity labels
-   */
-  @state()
-  private _showLabels!: boolean;
 
   /**
    * Whether to hide the icon
@@ -124,9 +116,6 @@ export class RoomStateIcon extends HassUpdateMixin(LitElement) {
     if (!equal(config, this._config)) {
       this.iconBackground =
         config.background?.options?.includes('icon_background') ?? false;
-
-      this._showLabels =
-        config.features?.includes('show_entity_labels') ?? false;
 
       // Calculate hiding logic for main room entity
       if (this.isMainRoomEntity) {
@@ -204,25 +193,6 @@ export class RoomStateIcon extends HassUpdateMixin(LitElement) {
       ...thresholdResult?.styles,
     };
 
-    // Get label (priority: state/threshold label > config label > attribute value > entity name)
-    let label: TemplateResult | string | undefined;
-    if (this._showLabels && !this._hideIconContent) {
-      // First priority: label from state/threshold result
-      const thresholdLabel = getEntityLabel(this.entity, thresholdResult);
-      if (thresholdLabel) {
-        label = thresholdLabel;
-      } else if (this.entity.config.label) {
-        // Second priority: configured label
-        label = this.entity.config.label;
-      } else if (this.entity.config.attribute) {
-        // Third priority: attribute value if attribute is configured
-        label = stateDisplay(this._hass, state, this.entity.config.attribute);
-      } else {
-        // Fallback: entity name
-        label = computeEntityName(state, this._hass);
-      }
-    }
-
     const icon = computeEntityIcon(this.entity, this._config, {
       thresholdResult,
     });
@@ -250,7 +220,12 @@ export class RoomStateIcon extends HassUpdateMixin(LitElement) {
               .icon=${icon}
             ></ha-state-icon>`}
         ${badgeElements}
-        ${label ? html`<div class="entity-label">${label}</div>` : nothing}
+        <room-entity-label
+          .hass=${this._hass}
+          .config=${this._config}
+          .entity=${this.entity}
+          .isMainRoomEntity=${this.isMainRoomEntity}
+        ></room-entity-label>
         ${renderStateDisplay(this._hass, this.entity, this._hideIconContent)}
       </div>
     `;

--- a/src/cards/components/room-state-icon/styles.ts
+++ b/src/cards/components/room-state-icon/styles.ts
@@ -66,16 +66,6 @@ export const styles = css`
     filter: var(--icon-filter, none);
   }
 
-  /* Entity label styling */
-  .entity-label {
-    position: absolute;
-    font-size: 0.7em;
-    text-align: center;
-    overflow: hidden;
-    margin-top: 75%;
-    display: var(--user-entity-label-display, block);
-  }
-
   /* Entity state styling */
   .entity-state {
     position: absolute;

--- a/src/cards/components/sensor-collection/sensor-collection.ts
+++ b/src/cards/components/sensor-collection/sensor-collection.ts
@@ -5,16 +5,14 @@ import {
   handleClickAction,
 } from '@delegates/action-handler-delegate';
 import { getIconResources } from '@delegates/retrievers/icons';
-import { sensorDataToDisplaySensors } from '@delegates/utils/sensor-utils';
 import {
   FALLBACK_DOMAIN_ICONS,
   type CategoryType,
   type IconResources,
 } from '@hass/data/icon';
 import type { HomeAssistant } from '@hass/types';
-import { stateDisplay } from '@html/state-display';
 import { processHomeAssistantColors } from '@theme/colors';
-import { getEntityLabel, getThresholdResult } from '@theme/threshold-color';
+import { getThresholdResult } from '@theme/threshold-color';
 import { stylesToHostCss } from '@theme/util/style-converter';
 import type { SensorConfig } from '@type/config/sensor';
 import type { EntityInformation, EntityState } from '@type/room';
@@ -24,6 +22,7 @@ import { CSSResult, LitElement, html, nothing, type TemplateResult } from 'lit';
 import { property } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { until } from 'lit/directives/until.js';
+import './sensor-label';
 import { styles } from './styles';
 
 /**
@@ -59,7 +58,6 @@ export class SensorCollection extends HassUpdateMixin(LitElement) {
   private hide!: boolean;
   @property({ type: String, reflect: true })
   private layout!: string;
-  private _hideLabels!: boolean;
 
   /**
    * Returns the component's styles
@@ -77,7 +75,6 @@ export class SensorCollection extends HassUpdateMixin(LitElement) {
     d(this.config, 'sensor-collection', 'set hass');
     this._hass = hass;
     this.hide = hasFeature(this.config, 'hide_sensor_icons');
-    this._hideLabels = hasFeature(this.config, 'hide_sensor_labels');
     this.layout = this.config.sensor_layout ?? 'default';
   }
 
@@ -110,7 +107,11 @@ export class SensorCollection extends HassUpdateMixin(LitElement) {
         return html`
           <div class="sensor">
             ${this.renderMultiIcon(s)}
-            ${this._hideLabels ? nothing : sensorDataToDisplaySensors(s)}
+            <room-sensor-label
+              .hass=${this._hass}
+              .config=${this.config}
+              .sensor=${s}
+            ></room-sensor-label>
           </div>
         `;
       }
@@ -142,10 +143,6 @@ export class SensorCollection extends HassUpdateMixin(LitElement) {
 
     // Get state/threshold-based styling result
     const result = getThresholdResult(info);
-
-    // Get label (priority: state/threshold label > config label)
-    const label = getEntityLabel(info, result);
-
     // Icon priority: state/threshold icon > configured icon > default
     // State-based icons override configured icons for dynamic behavior
     const icon = result?.icon || sensorConfig?.icon;
@@ -161,27 +158,13 @@ export class SensorCollection extends HassUpdateMixin(LitElement) {
         .actionHandler=${actionHandler(info)}
       >
         ${this.renderStateIcon(state, icon)}
-        ${this.renderSensorLabel(state, label, sensorConfig)}
+        <room-sensor-label
+          .hass=${this._hass}
+          .config=${this.config}
+          .entity=${info}
+        ></room-sensor-label>
       </div>
     `;
-  }
-
-  /**
-   * Renders the sensor label with proper fallback logic
-   * @param state - The entity state
-   * @param label - The configured label (if any)
-   * @param sensorConfig - The sensor configuration (if any)
-   * @returns The label content, attribute value, state display, or nothing if labels are hidden
-   */
-  private renderSensorLabel(
-    state: EntityState,
-    label?: string,
-    sensorConfig?: SensorConfig,
-  ): TemplateResult | typeof nothing {
-    if (this._hideLabels) return nothing;
-    if (label) return html`${label}`;
-
-    return stateDisplay(this._hass, state, sensorConfig?.attribute);
   }
 
   /**
@@ -227,7 +210,7 @@ export class SensorCollection extends HassUpdateMixin(LitElement) {
   }
 
   private renderStateIcon(
-    state?: any,
+    state?: EntityState,
     icon?: string,
   ): TemplateResult | typeof nothing {
     if (this.hide || !state) return nothing;

--- a/src/cards/components/sensor-collection/sensor-label.ts
+++ b/src/cards/components/sensor-collection/sensor-label.ts
@@ -1,0 +1,74 @@
+import { HassConfigMixin } from '@cards/mixins/hass-config-mixin';
+import { hasFeature } from '@config/feature';
+import { LabelTemplateConnection } from '@delegates/label-template-connection';
+import { sensorDataToDisplaySensors } from '@delegates/utils/sensor-utils';
+import { renderConfiguredEntityLabel } from '@html/render-label';
+import type { EntityInformation } from '@type/room';
+import type { AveragedSensor } from '@type/sensor';
+import { html, LitElement, nothing, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+const equal = require('fast-deep-equal');
+
+/**
+ * Label beside a sensor icon: threshold/state label, Jinja `label`, static
+ * text, or formatted state/attribute.
+ */
+@customElement('room-sensor-label')
+export class RoomSensorLabel extends HassConfigMixin(LitElement) {
+  private readonly _labelTemplateConn = new LabelTemplateConnection(() =>
+    this.requestUpdate(),
+  );
+
+  get show(): boolean {
+    return !hasFeature(this.config, 'hide_sensor_labels');
+  }
+
+  /*
+   * Entity information
+   */
+  @property({
+    type: Object,
+    hasChanged: (a: EntityInformation, b: EntityInformation) => !equal(a, b),
+  })
+  entity: EntityInformation | undefined;
+
+  /*
+   * Entity information
+   */
+  @property({
+    type: Object,
+    hasChanged: (a: EntityInformation, b: EntityInformation) => !equal(a, b),
+  })
+  sensor: AveragedSensor | undefined;
+
+  override disconnectedCallback(): void {
+    this._labelTemplateConn.disconnect();
+    super.disconnectedCallback();
+  }
+
+  /**
+   * renders the lit element card
+   * @returns {TemplateResult} The rendered HTML template
+   */
+  override render(): TemplateResult | typeof nothing {
+    if (!this.show) {
+      this._labelTemplateConn.disconnect();
+      return nothing;
+    }
+
+    if (this.sensor) {
+      return html`${sensorDataToDisplaySensors(this.sensor)}`;
+    }
+
+    if (!this.entity) {
+      return nothing;
+    }
+
+    return renderConfiguredEntityLabel(
+      this.hass,
+      this.entity,
+      this._labelTemplateConn,
+      'state-display',
+    );
+  }
+}

--- a/src/delegates/label-template-connection.ts
+++ b/src/delegates/label-template-connection.ts
@@ -1,0 +1,87 @@
+import { subscribeRenderTemplate } from '@hass/data/ws-templates';
+import type { HomeAssistant } from '@hass/types';
+import type { SubscriptionUnsubscribe } from '@hass/ws/types';
+
+/**
+ * One live Jinja `render_template` subscription for an entity `label` that
+ * contains `{{` / `{%`. Tears down when the template string, entity context,
+ * or hass instance should change.
+ */
+export class LabelTemplateConnection {
+  private _unsub?: Promise<SubscriptionUnsubscribe>;
+  private _subscriptionKey?: string;
+  private _callbackGen = 0;
+  private _displayedText = '';
+
+  constructor(private readonly _requestUpdate: () => void) {}
+
+  get displayedText(): string {
+    return this._displayedText;
+  }
+
+  sync(
+    hass: HomeAssistant | undefined,
+    entityId: string,
+    template: string | undefined,
+  ): void {
+    const trimmed = template?.trim();
+    if (!hass?.connection || !trimmed) {
+      this._tearDown();
+      this._displayedText = '';
+      this._subscriptionKey = undefined;
+      this._requestUpdate();
+      return;
+    }
+
+    const key = `${entityId}\0${trimmed}`;
+    if (this._subscriptionKey === key && this._unsub) {
+      return;
+    }
+
+    this._tearDown();
+    this._subscriptionKey = key;
+    this._displayedText = '';
+    this._callbackGen++;
+    const generation = this._callbackGen;
+
+    this._unsub = subscribeRenderTemplate(
+      hass.connection,
+      (result) => {
+        if (generation !== this._callbackGen) {
+          return;
+        }
+        if ('error' in result) {
+          console.warn(
+            'room-summary-card: label template:',
+            result.error,
+            `(${entityId})`,
+          );
+          return;
+        }
+        this._displayedText = result.result ?? '';
+        this._requestUpdate();
+      },
+      {
+        template: trimmed,
+        entity_ids: entityId,
+        strict: true,
+      },
+    );
+  }
+
+  private _tearDown(): void {
+    if (this._unsub) {
+      void this._unsub.then((u) => {
+        u();
+      });
+      this._unsub = undefined;
+    }
+  }
+
+  disconnect(): void {
+    this._tearDown();
+    this._subscriptionKey = undefined;
+    this._callbackGen++;
+    this._displayedText = '';
+  }
+}

--- a/src/hass/common/entity/compute_entity_name.ts
+++ b/src/hass/common/entity/compute_entity_name.ts
@@ -16,9 +16,7 @@ export const computeEntityName = (
   stateObj: HassEntity,
   hass: HomeAssistant,
 ): string | undefined => {
-  const entry = hass.entities[stateObj.entity_id] as
-    | EntityRegistryDisplayEntry
-    | undefined;
+  const entry = hass.entities[stateObj.entity_id];
 
   if (!entry) {
     // Fall back to state name if not in the entity registry (friendly name)

--- a/src/hass/common/string/is_template.ts
+++ b/src/hass/common/string/is_template.ts
@@ -1,0 +1,9 @@
+/**
+ * https://github.com/home-assistant/frontend/blob/dev/src/common/string/has-template.ts
+ */
+
+const TEMPLATE_SYNTAX = /{%|{{/;
+
+/** True when the string looks like Jinja (e.g. contains `{{` or `{%`). */
+export const isTemplateString = (value: string): boolean =>
+  TEMPLATE_SYNTAX.test(value);

--- a/src/hass/data/selector.ts
+++ b/src/hass/data/selector.ts
@@ -16,6 +16,7 @@ export type Selector =
   | ObjectSelector
   | SelectSelector
   | StringSelector
+  | TemplateSelector
   | UiActionSelector
   | UiColorSelector
   | UiStateContentSelector;
@@ -121,6 +122,12 @@ export interface StringSelector {
       | 'color';
     suffix?: string;
   };
+}
+
+export interface TemplateSelector {
+  template: {
+    preview?: boolean;
+  } | null;
 }
 
 export interface UiActionSelector {

--- a/src/hass/data/ws-templates.ts
+++ b/src/hass/data/ws-templates.ts
@@ -1,0 +1,43 @@
+/**
+ * Home Assistant `render_template` websocket subscription.
+ * @see https://github.com/home-assistant/frontend/blob/dev/src/data/ws-templates.ts
+ */
+
+import type { Connection, SubscriptionUnsubscribe } from '@hass/ws/types';
+
+export interface RenderTemplateResult {
+  result: string;
+  listeners: TemplateListeners;
+}
+
+export interface RenderTemplateError {
+  error: string;
+  level: 'ERROR' | 'WARNING';
+}
+
+export interface TemplateListeners {
+  all: boolean;
+  domains: string[];
+  entities: string[];
+  time: boolean;
+}
+
+export const subscribeRenderTemplate = (
+  conn: Connection,
+  onChange: (result: RenderTemplateResult | RenderTemplateError) => void,
+  params: {
+    template: string;
+    entity_ids?: string | string[];
+    variables?: Record<string, unknown>;
+    timeout?: number;
+    strict?: boolean;
+    report_errors?: boolean;
+  },
+): Promise<SubscriptionUnsubscribe> =>
+  conn.subscribeMessage(
+    (msg: RenderTemplateResult | RenderTemplateError) => onChange(msg),
+    {
+      type: 'render_template',
+      ...params,
+    },
+  );

--- a/src/html/render-label.ts
+++ b/src/html/render-label.ts
@@ -1,0 +1,54 @@
+import { LabelTemplateConnection } from '@delegates/label-template-connection';
+import { computeEntityName } from '@hass/common/entity/compute_entity_name';
+import { isTemplateString } from '@hass/common/string/is_template';
+import type { HomeAssistant } from '@hass/types';
+import { stateDisplay } from '@html/state-display';
+import { getEntityLabel, getThresholdResult } from '@theme/threshold-color';
+import type { EntityInformation } from '@type/room';
+import { html, nothing, type TemplateResult } from 'lit';
+
+/** Final fallback when no configured label applies. */
+export type EntityLabelFallback = 'entity-name' | 'state-display';
+
+/**
+ * Renders label content for an entity row: threshold/state label, Jinja
+ * `label`, static text, then the configured fallback.
+ * priority: state/threshold label > config label > attribute value > entity name
+ */
+export function renderConfiguredEntityLabel(
+  hass: HomeAssistant,
+  entity: EntityInformation,
+  conn: LabelTemplateConnection,
+  fallback: EntityLabelFallback,
+): TemplateResult | typeof nothing {
+  // First priority: label from state/threshold result
+  // or a configured label (second priority)
+  const thresholdResult = getThresholdResult(entity);
+  const label = getEntityLabel(entity, thresholdResult);
+
+  // check if the label is a template string
+  if (label && isTemplateString(label)) {
+    conn.sync(hass, entity.config.entity_id, label);
+    return html`${conn.displayedText}`;
+  }
+
+  conn.disconnect();
+
+  // if the label is not a template string, return it
+  if (label) {
+    return html`${label}`;
+  }
+
+  const state = entity.state;
+  if (!state) {
+    return nothing;
+  }
+
+  // Third priority: attribute value if attribute is configured
+  if (entity.config.attribute || fallback === 'state-display') {
+    return stateDisplay(hass, state, entity.config.attribute);
+  }
+
+  // Fallback: entity name
+  return html`${computeEntityName(state, hass)}`;
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -85,6 +85,7 @@
         "homeassistant": "Home Assistant"
       },
       "mode_label": "Mode",
+      "label": "Badge Text",
       "max_badges": "Maximum 4 badges allowed"
     },
     "entities": {

--- a/src/types/config/common.ts
+++ b/src/types/config/common.ts
@@ -13,7 +13,10 @@ export interface BaseEntityConfig {
   /** Unique identifier for the sensor entity */
   entity_id: string;
 
-  /** Custom label to display instead of default state display */
+  /**
+   * Label under the icon: plain text, or Jinja when it contains `{{` / `{%`
+   * (rendered live via the `render_template` websocket).
+   */
   label?: string;
 
   /** Attribute or attributes to display instead of entity state (single key or list for multiple values) */

--- a/src/types/config/entity.ts
+++ b/src/types/config/entity.ts
@@ -100,6 +100,9 @@ export interface BadgeConfig {
   /** Optional entity ID (defaults to parent entity) */
   entity_id?: string;
 
+  /** Text to show in the badge instead of an icon. Supports Jinja templates. */
+  label?: string;
+
   /** Badge position: top_right, top_left, bottom_right, bottom_left */
   position?: 'top_right' | 'top_left' | 'bottom_right' | 'bottom_left';
 

--- a/src/types/locale.ts
+++ b/src/types/locale.ts
@@ -191,6 +191,7 @@ export type TranslationKey =
   | 'editor.badge.mode.if_match'
   | 'editor.badge.mode.homeassistant'
   | 'editor.badge.mode_label'
+  | 'editor.badge.label'
   | 'editor.badge.max_badges';
 
 export interface Translation {

--- a/test/cards/components/badge/badge-label.spec.ts
+++ b/test/cards/components/badge/badge-label.spec.ts
@@ -1,0 +1,51 @@
+import { RoomBadgeLabel } from '@cards/components/badge/badge-label';
+import type { HomeAssistant } from '@hass/types';
+import { fixture } from '@open-wc/testing-helpers';
+import { expect } from 'chai';
+import { html, nothing } from 'lit';
+import { restore, stub } from 'sinon';
+
+describe('badge-label.ts', () => {
+  afterEach(() => {
+    restore();
+  });
+
+  it('should render plain badge label text', async () => {
+    const element = new RoomBadgeLabel();
+    element.label = '72F';
+
+    const result = element.render();
+    const el = await fixture(html`<span>${result}</span>`);
+
+    expect(el.textContent).to.equal('72F');
+  });
+
+  it('should render nothing when no label is configured', () => {
+    const element = new RoomBadgeLabel();
+
+    expect(element.render()).to.equal(nothing);
+  });
+
+  it('should sync template labels using the badge entity context', () => {
+    const element = new RoomBadgeLabel();
+    const hass = { connection: {} } as HomeAssistant;
+    const labelTemplateConn = (element as any)._labelTemplateConn;
+    const syncStub = stub(labelTemplateConn, 'sync').callsFake(() => {
+      labelTemplateConn._displayedText = '72F';
+    });
+
+    element.hass = hass;
+    element.entityId = 'sensor.temperature';
+    element.label = '{{ states("sensor.temperature") }}';
+    const result = element.render();
+
+    expect(result).to.not.equal(nothing);
+    expect(
+      syncStub.calledWith(
+        hass,
+        'sensor.temperature',
+        '{{ states("sensor.temperature") }}',
+      ),
+    ).to.be.true;
+  });
+});

--- a/test/cards/components/badge/badge.spec.ts
+++ b/test/cards/components/badge/badge.spec.ts
@@ -224,6 +224,45 @@ describe('badge.ts', () => {
         expect((stateIcon as any).stateObj).to.equal(mockEntityState);
         expect((stateIcon as any).icon).to.equal('mdi:light-on');
       });
+
+      it('should render badge label text instead of state icon', async () => {
+        element.badge = {
+          ...mockBadgeConfig,
+          mode: 'show_always',
+          label: '72F',
+        };
+
+        const result = element.render() as TemplateResult;
+        const el = await fixture(result);
+
+        expect(el.querySelector('ha-state-icon')).to.not.exist;
+        const badgeLabel = el.querySelector('room-badge-label') as HTMLElement;
+        expect(badgeLabel).to.exist;
+        expect((badgeLabel as any).hass).to.equal(mockHass);
+        expect((badgeLabel as any).entityId).to.equal('light.living_room');
+        expect((badgeLabel as any).label).to.equal('72F');
+      });
+
+      it('should prefer matching state label over badge label', async () => {
+        const matchingState: StateConfig = {
+          state: 'on',
+          icon_color: 'yellow',
+          label: 'Open',
+        };
+        getMatchingBadgeStateStub.returns(matchingState);
+        element.badge = {
+          ...mockBadgeConfig,
+          mode: 'show_always',
+          label: 'Closed',
+        };
+
+        const result = element.render() as TemplateResult;
+        const el = await fixture(result);
+
+        const badgeLabel = el.querySelector('room-badge-label') as HTMLElement;
+        expect(badgeLabel).to.exist;
+        expect((badgeLabel as any).label).to.equal('Open');
+      });
     });
 
     describe('styles handling', () => {

--- a/test/cards/components/editor/entity-detail-editor.spec.ts
+++ b/test/cards/components/editor/entity-detail-editor.spec.ts
@@ -151,23 +151,16 @@ describe('entity-detail-editor.ts', () => {
           selector: { entity: {} },
         },
         {
-          type: 'grid',
-          name: '',
+          name: 'icon',
+          label: 'editor.entity.entity_icon',
+          selector: {
+            icon: {},
+          },
+        },
+        {
+          name: 'label',
           label: 'editor.entity.entity_label',
-          schema: [
-            {
-              name: 'label',
-              label: 'editor.entity.entity_label',
-              selector: { text: {} },
-            },
-            {
-              name: 'icon',
-              label: 'editor.entity.entity_icon',
-              selector: {
-                icon: {},
-              },
-            },
-          ],
+          selector: { template: { preview: true } },
         },
         {
           name: 'attribute',

--- a/test/cards/components/editor/states-row-editor.spec.ts
+++ b/test/cards/components/editor/states-row-editor.spec.ts
@@ -157,23 +157,15 @@ describe('states-row-editor.ts', () => {
           selector: { ui_color: {} },
         },
         {
-          type: 'grid',
-          name: '',
-          label: 'editor.entity.entity_label',
-          schema: [
-            {
-              name: 'icon',
-              label: 'editor.entity.state.icon',
-              required: false,
-              selector: { icon: {} },
-            },
-            {
-              name: 'label',
-              label: 'editor.entity.state.label',
-              required: false,
-              selector: { text: {} },
-            },
-          ],
+          name: 'icon',
+          label: 'editor.entity.state.icon',
+          required: false,
+          selector: { icon: {} },
+        },
+        {
+          name: 'label',
+          label: 'editor.entity.state.label',
+          selector: { template: { preview: true } },
         },
         {
           name: 'attribute',
@@ -241,23 +233,15 @@ describe('states-row-editor.ts', () => {
           selector: { ui_color: {} },
         },
         {
-          type: 'grid',
-          name: '',
-          label: 'editor.entity.entity_label',
-          schema: [
-            {
-              name: 'icon',
-              label: 'editor.entity.state.icon',
-              required: false,
-              selector: { icon: {} },
-            },
-            {
-              name: 'label',
-              label: 'editor.entity.state.label',
-              required: false,
-              selector: { text: {} },
-            },
-          ],
+          name: 'icon',
+          label: 'editor.entity.state.icon',
+          required: false,
+          selector: { icon: {} },
+        },
+        {
+          name: 'label',
+          label: 'editor.entity.state.label',
+          selector: { template: { preview: true } },
         },
         {
           name: 'attribute',
@@ -319,23 +303,15 @@ describe('states-row-editor.ts', () => {
           selector: { ui_color: {} },
         },
         {
-          type: 'grid',
-          name: '',
-          label: 'editor.entity.entity_label',
-          schema: [
-            {
-              name: 'icon',
-              label: 'editor.entity.state.icon',
-              required: false,
-              selector: { icon: {} },
-            },
-            {
-              name: 'label',
-              label: 'editor.entity.state.label',
-              required: false,
-              selector: { text: {} },
-            },
-          ],
+          name: 'icon',
+          label: 'editor.entity.state.icon',
+          required: false,
+          selector: { icon: {} },
+        },
+        {
+          name: 'label',
+          label: 'editor.entity.state.label',
+          selector: { template: { preview: true } },
         },
         {
           name: 'attribute',

--- a/test/cards/components/editor/utils/badge-editor-schema.spec.ts
+++ b/test/cards/components/editor/utils/badge-editor-schema.spec.ts
@@ -29,7 +29,7 @@ describe('badge-editor-schema', () => {
     it('should return the correct schema structure', () => {
       const schema = getBadgeSchema('sensor.test', mockHass);
 
-      expect(schema).to.be.an('array').with.lengthOf(3);
+      expect(schema).to.be.an('array').with.lengthOf(4);
 
       expect(schema[0]).to.deep.equal({
         name: 'entity_id',
@@ -38,25 +38,32 @@ describe('badge-editor-schema', () => {
         selector: { entity: {} },
       });
 
-      expect(schema[1]).to.deep.include({
+      expect(schema[1]).to.deep.equal({
+        name: 'label',
+        required: false,
+        label: 'editor.badge.label',
+        selector: { template: { preview: true } },
+      });
+
+      expect(schema[2]).to.deep.include({
         name: 'position',
         required: false,
         label: 'editor.badge.position_label',
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const positionSchema = schema[1] as any;
+      const positionSchema = schema[2] as any;
       expect(positionSchema.selector.select.options).to.have.lengthOf(4);
       expect(positionSchema.selector.select.options[0].value).to.equal(
         'top_right',
       );
 
-      expect(schema[2]).to.deep.include({
+      expect(schema[3]).to.deep.include({
         name: 'mode',
         required: false,
         label: 'editor.badge.mode_label',
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const modeSchema = schema[2] as any;
+      const modeSchema = schema[3] as any;
       expect(modeSchema.selector.select.options).to.have.lengthOf(3);
       expect(modeSchema.selector.select.options[0].value).to.equal(
         'show_always',

--- a/test/cards/components/editor/utils/badge-editor-utils.spec.ts
+++ b/test/cards/components/editor/utils/badge-editor-utils.spec.ts
@@ -223,5 +223,25 @@ describe('badge-editor-utils', () => {
       const title = getBadgeTitle(badge);
       expect(title).to.equal('Badge top_right');
     });
+
+    it('should include a plain badge label preview', () => {
+      const badge: BadgeConfig = {
+        mode: 'show_always',
+        position: 'top_right',
+        label: 'Temperature',
+      };
+      const title = getBadgeTitle(badge);
+      expect(title).to.equal('Show Always (top_right) - Temperature');
+    });
+
+    it('should not include a Jinja badge label preview', () => {
+      const badge: BadgeConfig = {
+        mode: 'show_always',
+        position: 'top_right',
+        label: '{{ states("sensor.temp") }}',
+      };
+      const title = getBadgeTitle(badge);
+      expect(title).to.equal('Show Always (top_right)');
+    });
   });
 });

--- a/test/cards/components/room-state-icon/entity-label.spec.ts
+++ b/test/cards/components/room-state-icon/entity-label.spec.ts
@@ -1,0 +1,116 @@
+import { RoomEntityLabel } from '@cards/components/room-state-icon/entity-label';
+import type { HomeAssistant } from '@hass/types';
+import * as renderLabelModule from '@html/render-label';
+import { createStateEntity } from '@test/test-helpers';
+import type { Config } from '@type/config';
+import type { EntityInformation } from '@type/room';
+import { expect } from 'chai';
+import { html, nothing } from 'lit';
+import { stub } from 'sinon';
+
+describe('room-entity-label.ts', () => {
+  let element: RoomEntityLabel;
+  let mockHass: HomeAssistant;
+  let mockEntity: EntityInformation;
+  let renderConfiguredEntityLabelStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    const state = createStateEntity('light', 'living_room', 'on', {
+      friendly_name: 'Living Room Light',
+    });
+
+    mockHass = {
+      states: {
+        'light.living_room': state,
+      },
+      formatEntityState: () => 'on',
+    } as any as HomeAssistant;
+
+    mockEntity = {
+      config: { entity_id: 'light.living_room' },
+      state,
+    };
+
+    renderConfiguredEntityLabelStub = stub(
+      renderLabelModule,
+      'renderConfiguredEntityLabel',
+    ).returns(html`<span>Living Room Light</span>`);
+
+    element = new RoomEntityLabel();
+    element.hass = mockHass;
+    element.entity = mockEntity;
+    element.config = {
+      area: 'living_room',
+      features: ['show_entity_labels'],
+    } as Config;
+  });
+
+  afterEach(() => {
+    renderConfiguredEntityLabelStub.restore();
+  });
+
+  describe('show', () => {
+    it('returns true when entity labels are enabled', () => {
+      expect(element.show).to.be.true;
+    });
+
+    it('returns false when entity labels are not enabled', () => {
+      element.config = { area: 'living_room' } as Config;
+
+      expect(element.show).to.be.false;
+    });
+
+    it('returns false for the main room entity when hide_icon_only is enabled', () => {
+      element.isMainRoomEntity = true;
+      element.config = {
+        area: 'living_room',
+        features: ['show_entity_labels'],
+        background: {
+          options: ['hide_icon_only'],
+        },
+      } as Config;
+
+      expect(element.show).to.be.false;
+    });
+  });
+
+  describe('render', () => {
+    it('delegates visible labels to the shared entity label renderer', () => {
+      const result = element.render();
+
+      expect(result).to.not.equal(nothing);
+      expect(
+        renderConfiguredEntityLabelStub.calledWith(
+          mockHass,
+          mockEntity,
+          element['_labelTemplateConn'],
+          'entity-name',
+        ),
+      ).to.be.true;
+    });
+
+    it('returns nothing and disconnects templates when hidden', () => {
+      const disconnectStub = stub(element['_labelTemplateConn'], 'disconnect');
+      element.config = { area: 'living_room' } as Config;
+
+      const result = element.render();
+
+      expect(result).to.equal(nothing);
+      expect(disconnectStub.calledOnce).to.be.true;
+      expect(renderConfiguredEntityLabelStub.called).to.be.false;
+
+      disconnectStub.restore();
+    });
+  });
+
+  describe('disconnectedCallback', () => {
+    it('disconnects any active template subscription', () => {
+      const disconnectStub = stub(element['_labelTemplateConn'], 'disconnect');
+
+      element.disconnectedCallback();
+
+      expect(disconnectStub.calledOnce).to.be.true;
+      disconnectStub.restore();
+    });
+  });
+});

--- a/test/cards/components/room-state-icon/room-state-icon.spec.ts
+++ b/test/cards/components/room-state-icon/room-state-icon.spec.ts
@@ -34,7 +34,6 @@ describe('room-state-icon.ts', () => {
   let handleClickActionStub: sinon.SinonStub;
   let hasFeatureStub: sinon.SinonStub;
   let computeEntityNameStub: sinon.SinonStub;
-  let getEntityLabelStub: sinon.SinonStub;
   let getThresholdResultStub: sinon.SinonStub;
   let hasEntityFeatureStub: sinon.SinonStub;
   let stateDisplayStub: sinon.SinonStub;
@@ -98,9 +97,6 @@ describe('room-state-icon.ts', () => {
       computeEntityNameModule,
       'computeEntityName',
     ).returns('Living Room Light');
-    getEntityLabelStub = stub(thresholdColorModule, 'getEntityLabel').returns(
-      undefined,
-    );
     getThresholdResultStub = stub(
       thresholdColorModule,
       'getThresholdResult',
@@ -144,7 +140,6 @@ describe('room-state-icon.ts', () => {
     handleClickActionStub.restore();
     hasFeatureStub.restore();
     computeEntityNameStub.restore();
-    getEntityLabelStub.restore();
     getThresholdResultStub.restore();
     hasEntityFeatureStub.restore();
     stateDisplayStub.restore();
@@ -188,7 +183,6 @@ describe('room-state-icon.ts', () => {
 
       element.config = newConfig;
       expect(element['_config']).to.equal(newConfig);
-      expect(element['_showLabels']).to.be.true;
       expect(element['iconBackground']).to.be.true;
     });
 
@@ -310,47 +304,7 @@ describe('room-state-icon.ts', () => {
         .true;
     });
 
-    it('should show entity label when show_entity_labels feature is enabled', async () => {
-      // Set up config with show_entity_labels feature enabled
-      const configWithLabels = {
-        ...mockConfig,
-        features: ['show_entity_labels'],
-      } as Config;
-      element.config = configWithLabels;
-      computeEntityNameStub.returns('Living Room Light');
-
-      const result = element.render() as TemplateResult;
-      expect(result).to.not.equal(nothing);
-
-      // Render to actual DOM using fixture
-      const el = await fixture(result);
-
-      // Verify that computeEntityName was called with the correct parameters
-      expect(computeEntityNameStub.calledWith(mockEntityState, mockHass)).to.be
-        .true;
-
-      // Verify that the DOM includes the entity label
-      const entityLabel = el.querySelector('.entity-label');
-      expect(entityLabel).to.exist;
-      expect(entityLabel?.textContent?.trim()).to.equal('Living Room Light');
-    });
-
-    it('should not show entity label when show_entity_labels feature is disabled', async () => {
-      // Use default config without show_entity_labels feature
-      element.config = mockConfig;
-
-      const result = element.render() as TemplateResult;
-      expect(result).to.not.equal(nothing);
-
-      // Verify that computeEntityName was NOT called since the feature is disabled
-      expect(computeEntityNameStub.called).to.be.false;
-
-      // Verify that the template does NOT include the entity label
-      const templateString = result.strings.join('');
-      expect(templateString).to.not.include('class="entity-label"');
-    });
-
-    it('should prioritize threshold label over config label', async () => {
+    it('should pass entity and hass to the room-entity-label sub-component', async () => {
       const configWithLabels = {
         ...mockConfig,
         features: ['show_entity_labels'],
@@ -366,123 +320,12 @@ describe('room-state-icon.ts', () => {
       };
       element.entity = entityWithConfigLabel;
 
-      // Mock threshold result with label
-      getThresholdResultStub.returns({
-        label: 'Threshold Label',
-        icon: 'mdi:icon',
-        color: 'red',
-        styles: {},
-      });
-      getEntityLabelStub.returns('Threshold Label');
+      const el = await fixture(element.render() as TemplateResult);
 
-      const result = element.render() as TemplateResult;
-      const el = await fixture(result);
-
-      const entityLabel = el.querySelector('.entity-label');
+      const entityLabel = el.querySelector('room-entity-label') as any;
       expect(entityLabel).to.exist;
-      expect(entityLabel?.textContent?.trim()).to.equal('Threshold Label');
-      expect(getEntityLabelStub.called).to.be.true;
-    });
-
-    it('should use config label when threshold label is not available', async () => {
-      const configWithLabels = {
-        ...mockConfig,
-        features: ['show_entity_labels'],
-      } as Config;
-      element.config = configWithLabels;
-
-      const entityWithConfigLabel = {
-        ...mockEntity,
-        config: {
-          ...mockEntityConfig,
-          label: 'Config Label',
-        },
-      };
-      element.entity = entityWithConfigLabel;
-
-      // Mock threshold result without label
-      getThresholdResultStub.returns({
-        icon: 'mdi:icon',
-        color: 'red',
-        styles: {},
-      });
-      getEntityLabelStub.returns(undefined);
-
-      const result = element.render() as TemplateResult;
-      const el = await fixture(result);
-
-      const entityLabel = el.querySelector('.entity-label');
-      expect(entityLabel).to.exist;
-      expect(entityLabel?.textContent?.trim()).to.equal('Config Label');
-    });
-
-    it('should use state display for attribute when attribute is configured and no label', async () => {
-      const configWithLabels = {
-        ...mockConfig,
-        features: ['show_entity_labels'],
-      } as Config;
-      element.config = configWithLabels;
-
-      const entityWithAttribute = {
-        ...mockEntity,
-        config: {
-          ...mockEntityConfig,
-          attribute: 'brightness',
-        },
-      };
-      element.entity = entityWithAttribute;
-
-      // Mock threshold result without label
-      getThresholdResultStub.returns({
-        icon: 'mdi:icon',
-        color: 'red',
-        styles: {},
-      });
-      getEntityLabelStub.returns(undefined);
-      stateDisplayStub.returns(html`<span>50%</span>`);
-
-      const result = element.render() as TemplateResult;
-      const el = await fixture(result);
-
-      const entityLabel = el.querySelector('.entity-label');
-      expect(entityLabel).to.exist;
-      expect(
-        stateDisplayStub.calledWith(mockHass, mockEntityState, 'brightness'),
-      ).to.be.true;
-    });
-
-    it('should use entity name as fallback when no label or attribute', async () => {
-      const configWithLabels = {
-        ...mockConfig,
-        features: ['show_entity_labels'],
-      } as Config;
-      element.config = configWithLabels;
-
-      const entityWithoutLabel = {
-        ...mockEntity,
-        config: {
-          entity_id: 'light.living_room',
-        },
-      };
-      element.entity = entityWithoutLabel;
-
-      // Mock threshold result without label
-      getThresholdResultStub.returns({
-        icon: 'mdi:icon',
-        color: 'red',
-        styles: {},
-      });
-      getEntityLabelStub.returns(undefined);
-      computeEntityNameStub.returns('Living Room Light');
-
-      const result = element.render() as TemplateResult;
-      const el = await fixture(result);
-
-      const entityLabel = el.querySelector('.entity-label');
-      expect(entityLabel).to.exist;
-      expect(entityLabel?.textContent?.trim()).to.equal('Living Room Light');
-      expect(computeEntityNameStub.calledWith(mockEntityState, mockHass)).to.be
-        .true;
+      expect(entityLabel.entity).to.equal(entityWithConfigLabel);
+      expect(entityLabel.hass).to.equal(mockHass);
     });
   });
 

--- a/test/cards/components/sensor-collection/sensor-collection.spec.ts
+++ b/test/cards/components/sensor-collection/sensor-collection.spec.ts
@@ -13,7 +13,7 @@ import type { Config } from '@type/config';
 import type { EntityState } from '@type/room';
 import type { SensorData } from '@type/sensor';
 import { expect } from 'chai';
-import { html, nothing, type TemplateResult } from 'lit';
+import { html, nothing, render, type TemplateResult } from 'lit';
 import { stub } from 'sinon';
 
 describe('sensor-collection.ts', () => {
@@ -84,8 +84,6 @@ describe('sensor-collection.ts', () => {
       expect(element['_hass']).to.equal(mockHass);
       expect(hasFeatureStub.calledWith(element.config, 'hide_sensor_icons')).to
         .be.true;
-      expect(hasFeatureStub.calledWith(element.config, 'hide_sensor_labels')).to
-        .be.true;
     });
 
     it('should set layout from config', () => {
@@ -119,6 +117,119 @@ describe('sensor-collection.ts', () => {
     });
   });
 
+  describe('sensor render order', () => {
+    beforeEach(() => {
+      element.hass = mockHass;
+    });
+
+    it('should render averaged sensors before individual sensors', async () => {
+      element.sensors = {
+        averaged: [
+          {
+            domain: 'sensor',
+            device_class: 'temperature',
+            states: [
+              { entity_id: 'sensor.temp_a', state: '20' } as EntityState,
+            ],
+          },
+        ],
+        individual: [
+          { entity_id: 'sensor.humidity_a', state: '45' } as EntityState,
+          { entity_id: 'sensor.pressure_a', state: '1013' } as EntityState,
+        ],
+      } as SensorData;
+
+      const root = document.createElement('div');
+      render(element.render() as TemplateResult, root);
+
+      const sensorDivs = Array.from(root.querySelectorAll('.sensor'));
+      expect(sensorDivs).to.have.length(3);
+
+      // Each sensor div hosts an ha-state-icon (or ha-icon for multi-averaged).
+      // We assert that the averaged sensor (only one state ⇒ rendered like a single)
+      // comes first, then the individuals in config order.
+      const ids = sensorDivs.map(
+        (d) => (d.querySelector('ha-state-icon') as any)?.stateObj?.entity_id,
+      );
+      expect(ids).to.deep.equal([
+        'sensor.temp_a',
+        'sensor.humidity_a',
+        'sensor.pressure_a',
+      ]);
+    });
+
+    it('should preserve order across multiple averaged groups', async () => {
+      element.sensors = {
+        averaged: [
+          {
+            domain: 'sensor',
+            device_class: 'temperature',
+            states: [
+              { entity_id: 'sensor.temp_1', state: '20' } as EntityState,
+            ],
+          },
+          {
+            domain: 'sensor',
+            device_class: 'humidity',
+            states: [
+              { entity_id: 'sensor.humidity_1', state: '50' } as EntityState,
+            ],
+          },
+        ],
+        individual: [
+          { entity_id: 'sensor.battery_1', state: '90' } as EntityState,
+        ],
+      } as SensorData;
+
+      const root = document.createElement('div');
+      render(element.render() as TemplateResult, root);
+
+      const ids = Array.from(root.querySelectorAll('.sensor')).map(
+        (d) => (d.querySelector('ha-state-icon') as any)?.stateObj?.entity_id,
+      );
+      expect(ids).to.deep.equal([
+        'sensor.temp_1',
+        'sensor.humidity_1',
+        'sensor.battery_1',
+      ]);
+    });
+
+    it('should keep multi-averaged sensors before individual sensors', async () => {
+      element.sensors = {
+        averaged: [
+          {
+            domain: 'sensor',
+            device_class: 'temperature',
+            states: [
+              { entity_id: 'sensor.temp_m1', state: '20' } as EntityState,
+              { entity_id: 'sensor.temp_m2', state: '22' } as EntityState,
+            ],
+            uom: '°C',
+            average: 21,
+          } as any,
+        ],
+        individual: [
+          { entity_id: 'sensor.humidity_x', state: '45' } as EntityState,
+        ],
+      } as SensorData;
+
+      const root = document.createElement('div');
+      render(element.render() as TemplateResult, root);
+
+      const sensorDivs = Array.from(root.querySelectorAll('.sensor'));
+      expect(sensorDivs).to.have.length(2);
+
+      // First sensor is the multi-averaged group (rendered through renderMultiIcon path):
+      // it does NOT have an ha-state-icon, only a (deferred) ha-icon. The second sensor is
+      // the individual sensor with ha-state-icon for sensor.humidity_x.
+      expect(sensorDivs[0]!.querySelector('ha-state-icon')).to.not.exist;
+      expect(
+        (sensorDivs[1]!.querySelector('ha-state-icon') as any)?.stateObj
+          ?.entity_id,
+      ).to.equal('sensor.humidity_x');
+    });
+  });
+
   describe('renderSensor', () => {
     beforeEach(() => {
       element.hass = mockHass;
@@ -128,7 +239,11 @@ describe('sensor-collection.ts', () => {
       const sensor = element.sensors.averaged[0]!;
       const el = await fixture(element['renderSensor'](sensor, true));
 
-      expect(stateDisplayStub.called).to.be.true;
+      // Single averaged sensor renders through renderSingleSensor; label is delegated
+      // to <room-sensor-label> (priority logic is tested in render-label.spec.ts).
+      expect(el.tagName).to.equal('DIV');
+      expect(el.classList.contains('sensor')).to.be.true;
+      expect(el.querySelector('room-sensor-label')).to.exist;
     });
 
     it('should render multi averaged sensor correctly', async () => {
@@ -145,7 +260,11 @@ describe('sensor-collection.ts', () => {
 
       const el = await fixture(element['renderSensor'](sensor, true));
 
-      expect(sensorDataToDisplayStub.called).to.be.true;
+      // Averaged display text is delegated to <room-sensor-label>.
+      const label = el.querySelector('room-sensor-label') as any;
+      expect(label).to.exist;
+      expect(label.sensor).to.equal(sensor);
+      expect(sensorDataToDisplayStub.called).to.be.false;
     });
 
     it('should render individual sensor with configured class', async () => {
@@ -155,7 +274,7 @@ describe('sensor-collection.ts', () => {
       // Check that the sensor div exists and has the correct structure
       expect(el.tagName).to.equal('DIV');
       expect(el.classList.contains('sensor')).to.be.true;
-      expect(stateDisplayStub.called).to.be.true;
+      expect(el.querySelector('room-sensor-label')).to.exist;
     });
 
     it('should call stylesToHostCss with config styles', async () => {
@@ -195,13 +314,13 @@ describe('sensor-collection.ts', () => {
         .returns(true);
       element.hass = mockHass;
 
-      expect(element['renderStateIcon']({})).to.equal(nothing);
+      expect(element['renderStateIcon']({} as EntityState)).to.equal(nothing);
     });
 
     it('should render state icon when not hidden', async () => {
       const state = { entity_id: 'sensor.test', state: '20' };
       const el = await fixture(
-        element['renderStateIcon'](state) as TemplateResult,
+        element['renderStateIcon'](state as EntityState) as TemplateResult,
       );
 
       expect(el.tagName).to.equal('HA-STATE-ICON');
@@ -233,55 +352,7 @@ describe('sensor-collection.ts', () => {
       element.hass = mockHass;
     });
 
-    it('should hide labels when hide_sensor_labels is enabled for single sensors', async () => {
-      hasFeatureStub
-        .withArgs(element.config, 'hide_sensor_labels')
-        .returns(true);
-      element.hass = mockHass;
-
-      const sensor = element.sensors.individual[0]!;
-      const result = element['renderSingleSensor'](sensor as EntityState);
-
-      // The stateDisplay function should not be called when labels are hidden
-      expect(stateDisplayStub.called).to.be.false;
-    });
-
-    it('should hide labels when hide_sensor_labels is enabled for multi sensors', async () => {
-      hasFeatureStub
-        .withArgs(element.config, 'hide_sensor_labels')
-        .returns(true);
-      element.hass = mockHass;
-
-      const sensor = {
-        domain: 'sensor',
-        device_class: 'temperature',
-        states: [
-          { entity_id: 'sensor.temp1', state: '20' },
-          { entity_id: 'sensor.temp2', state: '22' },
-        ],
-        uom: '°C',
-        average: 21,
-      } as any;
-
-      const result = element['renderSensor'](sensor, true);
-
-      // The sensorDataToDisplaySensors function should not be called when labels are hidden
-      expect(sensorDataToDisplayStub.called).to.be.false;
-    });
-
-    it('should render labels when hide_sensor_labels is disabled', async () => {
-      hasFeatureStub
-        .withArgs(element.config, 'hide_sensor_labels')
-        .returns(false);
-      element.hass = mockHass;
-
-      const sensor = element.sensors.individual[0]!;
-      await fixture(element['renderSingleSensor'](sensor as EntityState));
-
-      expect(stateDisplayStub.called).to.be.true;
-    });
-
-    it('should pass attribute to stateDisplay when sensor config has attribute and no label', async () => {
+    it('should pass attribute through to the sensor label sub-component', async () => {
       hasFeatureStub
         .withArgs(element.config, 'hide_sensor_labels')
         .returns(false);
@@ -310,10 +381,15 @@ describe('sensor-collection.ts', () => {
       };
 
       const sensor = element.sensors.individual[0]!;
-      await fixture(element['renderSingleSensor'](sensor as EntityState));
+      const el = await fixture(
+        element['renderSingleSensor'](sensor as EntityState),
+      );
 
-      expect(stateDisplayStub.calledWith(mockHass, sensor, 'humidity')).to.be
-        .true;
+      const label = el.querySelector('room-sensor-label') as any;
+      expect(label).to.exist;
+      expect(label.entity.config.entity_id).to.equal('sensor.humidity');
+      expect(label.entity.config.attribute).to.equal('humidity');
+      expect(label.entity.state).to.equal(sensor);
     });
   });
 
@@ -785,7 +861,6 @@ describe('sensor-collection.ts', () => {
 
   describe('threshold-based sensor styling', () => {
     let getThresholdResultStub: sinon.SinonStub;
-    let getEntityLabelStub: sinon.SinonStub;
 
     beforeEach(() => {
       element.hass = mockHass;
@@ -793,14 +868,10 @@ describe('sensor-collection.ts', () => {
         thresholdColorModule,
         'getThresholdResult',
       ).returns(undefined);
-      getEntityLabelStub = stub(thresholdColorModule, 'getEntityLabel').returns(
-        undefined,
-      );
     });
 
     afterEach(() => {
       getThresholdResultStub.restore();
-      getEntityLabelStub.restore();
     });
 
     it('should pass thresholds to getThresholdResult', async () => {
@@ -979,7 +1050,7 @@ describe('sensor-collection.ts', () => {
       expect((icon as any)?.icon).to.equal('mdi:thermometer-alert');
     });
 
-    it('should apply threshold labels when threshold matches', async () => {
+    it('should forward threshold-labelled config to the sensor label sub-component', async () => {
       element.config = {
         sensors: [
           {
@@ -1013,15 +1084,17 @@ describe('sensor-collection.ts', () => {
         label: 'Hot',
         styles: undefined,
       });
-      getEntityLabelStub.returns('Hot');
 
       const sensor = element.sensors.individual[0]!;
       const el = await fixture(
         element['renderSingleSensor'](sensor as EntityState),
       );
 
-      // Verify getEntityLabel was called with the threshold result
-      expect(getEntityLabelStub.called).to.be.true;
+      // The label resolution (incl. threshold label) is tested in render-label.spec.ts.
+      // Here we just verify the label sub-component receives the entity carrying the threshold config.
+      const label = el.querySelector('room-sensor-label') as any;
+      expect(label).to.exist;
+      expect(label.entity.config.thresholds?.[0]?.label).to.equal('Hot');
     });
 
     it('should apply threshold styles when threshold matches', async () => {

--- a/test/cards/components/sensor-collection/sensor-label.spec.ts
+++ b/test/cards/components/sensor-collection/sensor-label.spec.ts
@@ -1,0 +1,145 @@
+import { RoomSensorLabel } from '@cards/components/sensor-collection/sensor-label';
+import * as featureModule from '@config/feature';
+import * as sensorUtilsModule from '@delegates/utils/sensor-utils';
+import type { HomeAssistant } from '@hass/types';
+import * as renderLabelModule from '@html/render-label';
+import { createStateEntityForEntityId as s } from '@test/test-helpers';
+import type { EntityInformation } from '@type/room';
+import type { AveragedSensor } from '@type/sensor';
+import { expect } from 'chai';
+import { html, nothing } from 'lit';
+import { stub } from 'sinon';
+
+describe('sensor-label.ts', () => {
+  let element: RoomSensorLabel;
+  let mockHass: HomeAssistant;
+  let mockEntity: EntityInformation;
+  let mockSensor: AveragedSensor;
+  let hasFeatureStub: sinon.SinonStub;
+  let sensorDataToDisplaySensorsStub: sinon.SinonStub;
+  let renderConfiguredEntityLabelStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    const state = s('sensor.temperature', '21', {
+      unit_of_measurement: '°C',
+    });
+
+    mockHass = {
+      states: {
+        'sensor.temperature': state,
+      },
+      formatEntityState: () => '21 °C',
+    } as any as HomeAssistant;
+
+    mockEntity = {
+      config: { entity_id: 'sensor.temperature' },
+      state,
+    };
+
+    mockSensor = {
+      domain: 'sensor',
+      device_class: 'temperature',
+      states: [state],
+      average: 21,
+      uom: '°C',
+    };
+
+    hasFeatureStub = stub(featureModule, 'hasFeature').returns(false);
+    sensorDataToDisplaySensorsStub = stub(
+      sensorUtilsModule,
+      'sensorDataToDisplaySensors',
+    ).returns('21°C');
+    renderConfiguredEntityLabelStub = stub(
+      renderLabelModule,
+      'renderConfiguredEntityLabel',
+    ).returns(html`<span>21 °C</span>`);
+
+    element = new RoomSensorLabel();
+    element.hass = mockHass;
+    element.config = { area: 'living_room' };
+    element.entity = mockEntity;
+  });
+
+  afterEach(() => {
+    hasFeatureStub.restore();
+    sensorDataToDisplaySensorsStub.restore();
+    renderConfiguredEntityLabelStub.restore();
+  });
+
+  describe('show', () => {
+    it('returns true when sensor labels are not hidden', () => {
+      expect(element.show).to.be.true;
+      expect(hasFeatureStub.calledWith(element.config, 'hide_sensor_labels')).to
+        .be.true;
+    });
+
+    it('returns false when hide_sensor_labels is enabled', () => {
+      hasFeatureStub
+        .withArgs(element.config, 'hide_sensor_labels')
+        .returns(true);
+
+      expect(element.show).to.be.false;
+    });
+  });
+
+  describe('render', () => {
+    it('renders averaged sensor display text before entity labels', () => {
+      element.sensor = mockSensor;
+
+      const result = element.render();
+
+      expect(result).to.not.equal(nothing);
+      expect(sensorDataToDisplaySensorsStub.calledWith(mockSensor)).to.be.true;
+      expect(renderConfiguredEntityLabelStub.called).to.be.false;
+    });
+
+    it('delegates entity labels to the shared label renderer', () => {
+      const result = element.render();
+
+      expect(result).to.not.equal(nothing);
+      expect(
+        renderConfiguredEntityLabelStub.calledWith(
+          mockHass,
+          mockEntity,
+          element['_labelTemplateConn'],
+          'state-display',
+        ),
+      ).to.be.true;
+    });
+
+    it('returns nothing when hidden and disconnects templates', () => {
+      const disconnectStub = stub(element['_labelTemplateConn'], 'disconnect');
+      hasFeatureStub
+        .withArgs(element.config, 'hide_sensor_labels')
+        .returns(true);
+
+      const result = element.render();
+
+      expect(result).to.equal(nothing);
+      expect(disconnectStub.calledOnce).to.be.true;
+      expect(sensorDataToDisplaySensorsStub.called).to.be.false;
+      expect(renderConfiguredEntityLabelStub.called).to.be.false;
+
+      disconnectStub.restore();
+    });
+
+    it('returns nothing when neither sensor nor entity is set', () => {
+      element.entity = undefined;
+
+      expect(element.render()).to.equal(nothing);
+      expect(sensorDataToDisplaySensorsStub.called).to.be.false;
+      expect(renderConfiguredEntityLabelStub.called).to.be.false;
+    });
+  });
+
+  describe('disconnectedCallback', () => {
+    it('disconnects any active template subscription', () => {
+      const disconnectStub = stub(element['_labelTemplateConn'], 'disconnect');
+
+      element.disconnectedCallback();
+
+      expect(disconnectStub.calledOnce).to.be.true;
+      disconnectStub.restore();
+    });
+  });
+});

--- a/test/delegates/label-template-connection.spec.ts
+++ b/test/delegates/label-template-connection.spec.ts
@@ -1,0 +1,143 @@
+import { LabelTemplateConnection } from '@delegates/label-template-connection';
+import type { HomeAssistant } from '@hass/types';
+import { expect } from 'chai';
+import { stub } from 'sinon';
+
+describe('label-template-connection.ts', () => {
+  let conn: LabelTemplateConnection;
+  let hass: HomeAssistant;
+  let requestUpdate: sinon.SinonStub;
+  let subscribeMessage: sinon.SinonStub;
+  let callbacks: ((msg: unknown) => void)[];
+  let messages: unknown[];
+  let unsubscribes: sinon.SinonStub[];
+
+  beforeEach(() => {
+    requestUpdate = stub();
+    callbacks = [];
+    messages = [];
+    unsubscribes = [];
+
+    subscribeMessage = stub().callsFake((callback, message) => {
+      const unsubscribe = stub();
+      callbacks.push(callback);
+      messages.push(message);
+      unsubscribes.push(unsubscribe);
+      return Promise.resolve(unsubscribe);
+    });
+
+    hass = {
+      connection: {
+        subscribeMessage,
+      },
+    } as unknown as HomeAssistant;
+
+    conn = new LabelTemplateConnection(requestUpdate);
+  });
+
+  it('starts with no displayed text', () => {
+    expect(conn.displayedText).to.equal('');
+  });
+
+  it('subscribes to a trimmed template and updates displayed text', () => {
+    conn.sync(hass, 'sensor.temperature', '  {{ states("sensor.temperature") }}  ');
+
+    expect(messages[0]).to.deep.equal({
+      type: 'render_template',
+      template: '{{ states("sensor.temperature") }}',
+      entity_ids: 'sensor.temperature',
+      strict: true,
+    });
+
+    callbacks[0]?.({
+      result: '21 °C',
+      listeners: {
+        all: false,
+        domains: [],
+        entities: ['sensor.temperature'],
+        time: false,
+      },
+    });
+
+    expect(conn.displayedText).to.equal('21 °C');
+    expect(requestUpdate.calledOnce).to.be.true;
+  });
+
+  it('does not resubscribe for the same entity and template', () => {
+    conn.sync(hass, 'sensor.temperature', '{{ states("sensor.temperature") }}');
+    conn.sync(hass, 'sensor.temperature', '  {{ states("sensor.temperature") }}  ');
+
+    expect(subscribeMessage.calledOnce).to.be.true;
+  });
+
+  it('tears down the previous subscription and ignores stale callbacks', async () => {
+    conn.sync(hass, 'sensor.temperature', '{{ states("sensor.temperature") }}');
+    conn.sync(hass, 'sensor.humidity', '{{ states("sensor.humidity") }}');
+    await Promise.resolve();
+
+    expect(unsubscribes[0]?.calledOnce).to.be.true;
+
+    callbacks[0]?.({
+      result: 'stale',
+      listeners: { all: false, domains: [], entities: [], time: false },
+    });
+    callbacks[1]?.({
+      result: '45%',
+      listeners: { all: false, domains: [], entities: [], time: false },
+    });
+
+    expect(conn.displayedText).to.equal('45%');
+    expect(requestUpdate.calledOnce).to.be.true;
+  });
+
+  it('clears and tears down when sync receives no usable template', async () => {
+    conn.sync(hass, 'sensor.temperature', '{{ states("sensor.temperature") }}');
+    callbacks[0]?.({
+      result: '21 °C',
+      listeners: { all: false, domains: [], entities: [], time: false },
+    });
+
+    conn.sync(hass, 'sensor.temperature', '  ');
+    await Promise.resolve();
+
+    expect(unsubscribes[0]?.calledOnce).to.be.true;
+    expect(conn.displayedText).to.equal('');
+    expect(requestUpdate.calledTwice).to.be.true;
+  });
+
+  it('disconnects and ignores callbacks from the old subscription', async () => {
+    conn.sync(hass, 'sensor.temperature', '{{ states("sensor.temperature") }}');
+    callbacks[0]?.({
+      result: '21 °C',
+      listeners: { all: false, domains: [], entities: [], time: false },
+    });
+
+    conn.disconnect();
+    await Promise.resolve();
+    callbacks[0]?.({
+      result: 'stale',
+      listeners: { all: false, domains: [], entities: [], time: false },
+    });
+
+    expect(unsubscribes[0]?.calledOnce).to.be.true;
+    expect(conn.displayedText).to.equal('');
+    expect(requestUpdate.calledOnce).to.be.true;
+  });
+
+  it('warns but keeps current text when Home Assistant returns an error', () => {
+    const warnStub = stub(console, 'warn');
+    conn.sync(hass, 'sensor.temperature', '{{ broken }}');
+
+    callbacks[0]?.({
+      error: 'Template error',
+      level: 'ERROR',
+    });
+
+    expect(warnStub.calledWithMatch('room-summary-card: label template:')).to.be
+      .true;
+    expect(conn.displayedText).to.equal('');
+    expect(requestUpdate.called).to.be.false;
+
+    warnStub.restore();
+  });
+});

--- a/test/hass/common/string/is_template.spec.ts
+++ b/test/hass/common/string/is_template.spec.ts
@@ -1,0 +1,16 @@
+import { isTemplateString } from '@hass/common/string/is_template';
+import { expect } from 'chai';
+
+describe('is_template.ts', () => {
+  it('detects {{', () => {
+    expect(isTemplateString('{{ states("sensor.a") }}')).to.be.true;
+  });
+
+  it('detects {%', () => {
+    expect(isTemplateString('{% set x = 1 %}')).to.be.true;
+  });
+
+  it('returns false for plain text', () => {
+    expect(isTemplateString('Living Room')).to.be.false;
+  });
+});

--- a/test/hass/data/ws-templates.spec.ts
+++ b/test/hass/data/ws-templates.spec.ts
@@ -1,0 +1,40 @@
+import { subscribeRenderTemplate } from '@hass/data/ws-templates';
+import type { Connection } from '@hass/ws/types';
+import { expect } from 'chai';
+import { stub } from 'sinon';
+
+describe('ws-templates.ts', () => {
+  it('subscribes with render_template message and forwards results', async () => {
+    let capturedMsg: unknown;
+    let capturedCb: ((msg: unknown) => void) | undefined;
+    const unsubscribe = stub();
+    const subscribeMessage = stub().callsFake(
+      (cb: (msg: unknown) => void, msg: unknown) => {
+        capturedCb = cb;
+        capturedMsg = msg;
+        return Promise.resolve(unsubscribe);
+      },
+    );
+    const conn = { subscribeMessage } as unknown as Connection;
+    const onChange = stub();
+
+    const unsub = await subscribeRenderTemplate(conn, onChange, {
+      template: '{{ states("sensor.temp") }}',
+      entity_ids: 'sensor.temp',
+    });
+
+    expect(capturedMsg).to.deep.equal({
+      type: 'render_template',
+      template: '{{ states("sensor.temp") }}',
+      entity_ids: 'sensor.temp',
+    });
+    expect(unsub).to.equal(unsubscribe);
+
+    capturedCb?.({ result: '21 °C', listeners: { all: false, domains: [], entities: ['sensor.temp'], time: false } });
+    expect(onChange.calledOnce).to.be.true;
+    expect(onChange.firstCall.args[0]).to.deep.equal({
+      result: '21 °C',
+      listeners: { all: false, domains: [], entities: ['sensor.temp'], time: false },
+    });
+  });
+});

--- a/test/html/render-label.spec.ts
+++ b/test/html/render-label.spec.ts
@@ -1,0 +1,222 @@
+import { LabelTemplateConnection } from '@delegates/label-template-connection';
+import * as computeEntityNameModule from '@hass/common/entity/compute_entity_name';
+import type { HomeAssistant } from '@hass/types';
+import { renderConfiguredEntityLabel } from '@html/render-label';
+import * as stateDisplayModule from '@html/state-display';
+import { fixture } from '@open-wc/testing-helpers';
+import { createStateEntity } from '@test/test-helpers';
+import * as thresholdColorModule from '@theme/threshold-color';
+import type { EntityInformation } from '@type/room';
+import { expect } from 'chai';
+import { html, nothing } from 'lit';
+import { stub } from 'sinon';
+
+describe('render-label.ts', () => {
+  let getThresholdResultStub: sinon.SinonStub;
+  let getEntityLabelStub: sinon.SinonStub;
+  let stateDisplayStub: sinon.SinonStub;
+  let computeEntityNameStub: sinon.SinonStub;
+
+  const state = createStateEntity('light', 'living_room', 'on', {
+    friendly_name: 'Living Room Light',
+  });
+
+  const baseEntity: EntityInformation = {
+    config: { entity_id: 'light.living_room' },
+    state,
+  };
+
+  const hass = {
+    states: { 'light.living_room': state },
+    formatEntityState: () => 'on',
+    connection: {},
+  } as any as HomeAssistant;
+
+  let conn: LabelTemplateConnection;
+  let requestUpdateCalls: number;
+
+  beforeEach(() => {
+    requestUpdateCalls = 0;
+    conn = new LabelTemplateConnection(() => {
+      requestUpdateCalls++;
+    });
+
+    getThresholdResultStub = stub(thresholdColorModule, 'getThresholdResult');
+    getEntityLabelStub = stub(thresholdColorModule, 'getEntityLabel');
+    stateDisplayStub = stub(stateDisplayModule, 'stateDisplay').returns(
+      html`<span class="state-display">state-display</span>`,
+    );
+    computeEntityNameStub = stub(
+      computeEntityNameModule,
+      'computeEntityName',
+    ).returns('Living Room Light');
+  });
+
+  afterEach(() => {
+    getThresholdResultStub.restore();
+    getEntityLabelStub.restore();
+    stateDisplayStub.restore();
+    computeEntityNameStub.restore();
+  });
+
+  describe('label priority order', () => {
+    it('prioritizes threshold label over config label', async () => {
+      getThresholdResultStub.returns({ label: 'Threshold Label' });
+      getEntityLabelStub.returns('Threshold Label');
+
+      const entity: EntityInformation = {
+        ...baseEntity,
+        config: { entity_id: 'light.living_room', label: 'Config Label' },
+      };
+
+      const el = await fixture(
+        html`<div>
+          ${renderConfiguredEntityLabel(hass, entity, conn, 'entity-name')}
+        </div>`,
+      );
+
+      expect(el.textContent?.trim()).to.equal('Threshold Label');
+      expect(
+        getEntityLabelStub.calledWith(entity, { label: 'Threshold Label' }),
+      ).to.be.true;
+    });
+
+    it('uses config label when no threshold label is present', async () => {
+      getThresholdResultStub.returns(undefined);
+      getEntityLabelStub.returns('Config Label');
+
+      const entity: EntityInformation = {
+        ...baseEntity,
+        config: { entity_id: 'light.living_room', label: 'Config Label' },
+      };
+
+      const el = await fixture(
+        html`<div>
+          ${renderConfiguredEntityLabel(hass, entity, conn, 'entity-name')}
+        </div>`,
+      );
+
+      expect(el.textContent?.trim()).to.equal('Config Label');
+      expect(stateDisplayStub.called).to.be.false;
+      expect(computeEntityNameStub.called).to.be.false;
+    });
+
+    it('falls back to attribute state-display when no label and attribute is configured', async () => {
+      getThresholdResultStub.returns(undefined);
+      getEntityLabelStub.returns(undefined);
+
+      const entity: EntityInformation = {
+        ...baseEntity,
+        config: { entity_id: 'light.living_room', attribute: 'brightness' },
+      };
+
+      await fixture(
+        html`<div>
+          ${renderConfiguredEntityLabel(hass, entity, conn, 'entity-name')}
+        </div>`,
+      );
+
+      expect(stateDisplayStub.calledWith(hass, state, 'brightness')).to.be.true;
+      expect(computeEntityNameStub.called).to.be.false;
+    });
+
+    it('falls back to state-display when fallback is "state-display" (sensor row)', async () => {
+      getThresholdResultStub.returns(undefined);
+      getEntityLabelStub.returns(undefined);
+
+      await fixture(
+        html`<div>
+          ${renderConfiguredEntityLabel(
+            hass,
+            baseEntity,
+            conn,
+            'state-display',
+          )}
+        </div>`,
+      );
+
+      expect(stateDisplayStub.calledWith(hass, state, undefined)).to.be.true;
+      expect(computeEntityNameStub.called).to.be.false;
+    });
+
+    it('falls back to entity name when no label/attribute and fallback is "entity-name"', async () => {
+      getThresholdResultStub.returns(undefined);
+      getEntityLabelStub.returns(undefined);
+
+      const el = await fixture(
+        html`<div>
+          ${renderConfiguredEntityLabel(hass, baseEntity, conn, 'entity-name')}
+        </div>`,
+      );
+
+      expect(el.textContent?.trim()).to.equal('Living Room Light');
+      expect(computeEntityNameStub.calledWith(state, hass)).to.be.true;
+      expect(stateDisplayStub.called).to.be.false;
+    });
+
+    it('returns nothing when state is missing and no label resolved', () => {
+      getThresholdResultStub.returns(undefined);
+      getEntityLabelStub.returns(undefined);
+
+      const entity: EntityInformation = {
+        config: { entity_id: 'light.living_room' },
+        state: undefined,
+      };
+
+      const result = renderConfiguredEntityLabel(
+        hass,
+        entity,
+        conn,
+        'entity-name',
+      );
+      expect(result).to.equal(nothing);
+    });
+  });
+
+  describe('template label (Jinja)', () => {
+    it('syncs the template subscription and renders rendered text when available', () => {
+      getThresholdResultStub.returns(undefined);
+      getEntityLabelStub.returns('{{ states("sensor.x") }}');
+
+      const syncStub = stub(conn, 'sync').callsFake(function (
+        this: LabelTemplateConnection,
+      ) {
+        (this as any)._displayedText = 'rendered';
+      });
+      // emulate displayedText getter via Object.defineProperty
+      Object.defineProperty(conn, 'displayedText', {
+        get: () => 'rendered',
+        configurable: true,
+      });
+
+      const result = renderConfiguredEntityLabel(
+        hass,
+        baseEntity,
+        conn,
+        'entity-name',
+      );
+
+      expect(
+        syncStub.calledWith(
+          hass,
+          'light.living_room',
+          '{{ states("sensor.x") }}',
+        ),
+      ).to.be.true;
+      expect(result).to.not.equal(nothing);
+      syncStub.restore();
+    });
+
+    it('disconnects the template subscription when label is plain text', () => {
+      getThresholdResultStub.returns(undefined);
+      getEntityLabelStub.returns('Plain Label');
+
+      const disconnectStub = stub(conn, 'disconnect');
+
+      renderConfiguredEntityLabel(hass, baseEntity, conn, 'entity-name');
+
+      expect(disconnectStub.called).to.be.true;
+      disconnectStub.restore();
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1235,10 +1235,10 @@
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/fake-timers@^15.3.2":
-  version "15.3.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz#afecc36681e26aab9e0fe809fd9ad578096a3058"
-  integrity sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==
+"@sinonjs/fake-timers@^15.4.0":
+  version "15.4.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz#5d40c151a9e66075fe4520bec40bccfe54931962"
+  integrity sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==
   dependencies:
     "@sinonjs/commons" "^3.0.1"
 
@@ -2238,10 +2238,10 @@ diff@^7.0.0:
   resolved "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz"
   integrity sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==
 
-diff@^8.0.4:
-  version "8.0.4"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.4.tgz#4f5baf3188b9b2431117b962eb20ba330fadf696"
-  integrity sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==
+diff@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-9.0.0.tgz#297c31cd7c280f13dfe335791ec2063bd4a73a6f"
+  integrity sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -4002,15 +4002,15 @@ signal-exit@^4.0.1:
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
-sinon@^21.1.2:
-  version "21.1.2"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-21.1.2.tgz#2404a6003853e6fc30430825fd21fe87675f29bf"
-  integrity sha512-FS6mN+/bx7e2ajpXkEmOcWB6xBzWiuNoAQT18/+a20SS4U7FSYl8Ms7N6VTUxN/1JAjkx7aXp+THMC8xdpp0gA==
+sinon@^22.0.0:
+  version "22.0.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-22.0.0.tgz#01cea95c919468f6ef01e21d406397e5c02aad9b"
+  integrity sha512-sq/6DpdXOrLyfbKlXLg/Usc7xu8YXPeLkOFZRvA3bNUSA2lhbrZ06yuXbH1fkzBPCbz9O10+7hznzUsjaYNm0Q==
   dependencies:
     "@sinonjs/commons" "^3.0.1"
-    "@sinonjs/fake-timers" "^15.3.2"
+    "@sinonjs/fake-timers" "^15.4.0"
     "@sinonjs/samsam" "^10.0.2"
-    diff "^8.0.4"
+    diff "^9.0.0"
 
 slash@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
**Documentation:** [Label templates (Jinja)](configuration/LABEL-TEMPLATES.md)

Entity, sensor, and badge **labels** can now use **Jinja2 templates**, not only fixed text. The same applies to `label` on **state** and **threshold** rows when you want the caption to change with conditions _and_ pull live data from other entities!

<img width="1770" height="636" alt="image" src="https://github.com/user-attachments/assets/28b389db-52bb-4361-9a46-d6a871c82066" />

<img width="736" height="730" alt="image" src="https://github.com/user-attachments/assets/03a6efce-8870-4885-b277-4d450768056e" />


### What you can do

- Show another entity’s state under an icon (e.g. temperature under a light).
- Put short live values directly on badges (e.g. temperature or humidity on the icon corner).
- Keep simple text labels unchanged (`Kitchen`, `Door`).
- Use templates on threshold/state rows for advanced captions (e.g. `Hot {{ states('sensor.temp') }}°`).

Enable icon labels with the `show_entity_labels` feature. Sensor labels follow the existing sensor label rules (see [sensor configuration](configuration/SENSOR-CONFIGURATION.md)).

### Quick example

```yaml
type: custom:room-summary-card
area: living_room
features:
  - show_entity_labels
entities:
  - entity_id: light.living_room
    label: "{{ states('sensor.living_room_temperature') | round(1) }}°"
    badges:
      - entity_id: sensor.living_room_temperature
        position: top_right
        mode: show_always
        label: "{{ states('sensor.living_room_temperature') | round(0) }}°"
sensors:
  - entity_id: sensor.living_room_humidity
    label: "{{ states('sensor.living_room_temperature') | round(1) }}° / {{ states('sensor.living_room_humidity') | int }}%"
```

Templates are evaluated by Home Assistant; see the [templating docs](https://www.home-assistant.io/docs/configuration/templating/) for syntax.

More examples (state/threshold labels, fallbacks, editor tips): **[Label templates (Jinja)](configuration/LABEL-TEMPLATES.md)**.
