### PR TITLE
fix: merge config.actions into room icon click handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@open-wc/testing": "^4.0.0",
     "@parcel/transformer-inline-string": "^2.16.4",
-    "@playwright/test": "^1.51.0",
+    "@playwright/test": "^1.60.0",
     "@testing-library/dom": "^10.4.1",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "@types/chai": "^5.2.3",
-    "@types/jsdom": "^28.0.1",
+    "@types/jsdom": "^28.0.3",
     "@types/mocha": "^10.0.10",
     "@types/sinon": "^21.0.1",
     "chai": "^6.2.2",
@@ -60,7 +60,7 @@
     "@lit/task": "^1.0.3",
     "async-memoize-one": "^1.2.1",
     "fast-deep-equal": "^3.1.3",
-    "lit": "^3.3.2",
+    "lit": "^3.3.3",
     "memoize-one": "^6.0.0"
   }
 }

--- a/src/cards/card.ts
+++ b/src/cards/card.ts
@@ -258,17 +258,9 @@ export class RoomSummaryCard extends SubscribeEntityStateMixin(LitElement) {
       return nothing;
     }
 
-    const actions = {
-      ...this._roomEntity,
-      config: {
-        ...this._roomEntity.config,
-        ...this._config.actions,
-      },
-    };
-
     const roomEntity = renderRoomIcon(
       this._hass,
-      actions,
+      this._roomEntity,
       this._config,
       {
         isMainRoomEntity: true,
@@ -297,6 +289,13 @@ export class RoomSummaryCard extends SubscribeEntityStateMixin(LitElement) {
       this,
     );
 
+    const actions = {
+      ...this._roomEntity,
+      config: {
+        ...this._roomEntity.config,
+        ...this._config.actions,
+      },
+    };
 
     return html`
       <ha-card style="${cardStyle}">

--- a/src/cards/card.ts
+++ b/src/cards/card.ts
@@ -258,9 +258,17 @@ export class RoomSummaryCard extends SubscribeEntityStateMixin(LitElement) {
       return nothing;
     }
 
+    const actions = {
+      ...this._roomEntity,
+      config: {
+        ...this._roomEntity.config,
+        ...this._config.actions,
+      },
+    };
+
     const roomEntity = renderRoomIcon(
       this._hass,
-      this._roomEntity,
+      actions,
       this._config,
       {
         isMainRoomEntity: true,
@@ -289,13 +297,6 @@ export class RoomSummaryCard extends SubscribeEntityStateMixin(LitElement) {
       this,
     );
 
-    const actions = {
-      ...this._roomEntity,
-      config: {
-        ...this._roomEntity.config,
-        ...this._config.actions,
-      },
-    };
 
     return html`
       <ha-card style="${cardStyle}">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1221,12 +1221,12 @@
   resolved "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@playwright/test@^1.51.0":
-  version "1.59.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.59.1.tgz#5c4d38eac84a61527af466602ae20277685a02d6"
-  integrity sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==
+"@playwright/test@^1.60.0":
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.60.0.tgz#e696c31427e8882851235cd556dc2490c3206d97"
+  integrity sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==
   dependencies:
-    playwright "1.59.1"
+    playwright "1.60.0"
 
 "@sinonjs/commons@^3.0.1":
   version "3.0.1"
@@ -1524,14 +1524,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jsdom@^28.0.1":
-  version "28.0.1"
-  resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-28.0.1.tgz#2c014d8c0eca6135233519bff8c49f7aadfeda63"
-  integrity sha512-GJq2QE4TAZ5ajSoCasn5DOFm8u1mI3tIFvM5tIq3W5U/RTB6gsHwc6Yhpl91X9VSDOUVblgXmG+2+sSvFQrdlw==
+"@types/jsdom@^28.0.3":
+  version "28.0.3"
+  resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-28.0.3.tgz#a5a900ae4d5bb1d874dee24a89afc06b34d3c1a0"
+  integrity sha512-/HQ2uFoetFTXuye8vzIcHw2z6Fwi7Hi/qcgC+RoS9NCyewiqxhVGqlG+ViGB6lkax481R6dmhf1I7lIGlzJStQ==
   dependencies:
     "@types/node" "*"
     "@types/tough-cookie" "*"
-    parse5 "^7.0.0"
+    parse5 "^8.0.0"
     undici-types "^7.21.0"
 
 "@types/keygrip@*":
@@ -2305,11 +2305,6 @@ encodeurl@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz"
   integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
-
-entities@^6.0.0:
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz"
-  integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
 
 entities@^8.0.0:
   version "8.0.0"
@@ -3152,10 +3147,10 @@ lit-element@^4.2.0:
   dependencies:
     "@types/trusted-types" "^2.0.2"
 
-"lit@^2.0.0 || ^3.0.0", lit@^3.0.0, lit@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/lit/-/lit-3.3.2.tgz#d9230ebbf237bfd3d2091bc0b56c576a470ac4d7"
-  integrity sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==
+"lit@^2.0.0 || ^3.0.0", lit@^3.0.0, lit@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/lit/-/lit-3.3.3.tgz#93579885e51a20a772c68482a34706fe1636e8f0"
+  integrity sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==
   dependencies:
     "@lit/reactive-element" "^2.1.0"
     lit-element "^4.2.0"
@@ -3657,14 +3652,7 @@ parse5@^6.0.1:
   resolved "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
-parse5@^7.0.0:
-  version "7.3.0"
-  resolved "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz"
-  integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
-  dependencies:
-    entities "^6.0.0"
-
-parse5@^8.0.1:
+parse5@^8.0.0, parse5@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-8.0.1.tgz#f43bcd2cd683efe084075333e9ce0da7d06da31e"
   integrity sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==
@@ -3721,17 +3709,17 @@ pkg-dir@^4.1.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright-core@1.59.1:
-  version "1.59.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.59.1.tgz#d8a2b28bcb8f2bd08ef3df93b02ae83c813244b2"
-  integrity sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==
+playwright-core@1.60.0:
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.60.0.tgz#24e0d9cc4730713db5dffcace29b5e4696b1907a"
+  integrity sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==
 
-playwright@1.59.1:
-  version "1.59.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.59.1.tgz#f7b0ca61637ae25264cec370df671bbe1f368a4a"
-  integrity sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==
+playwright@1.60.0:
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.60.0.tgz#89710863a51f21112633ef8b6b182594d3bfd7b5"
+  integrity sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==
   dependencies:
-    playwright-core "1.59.1"
+    playwright-core "1.60.0"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
## Problem

When \hide_room_icon\ is enabled, clicking anywhere on the card body (the hidden \.box\ div) navigates to \/area\ instead of respecting the user's \ctions.tap_action\ config. Only clicking the room name text correctly uses \config.actions\.

### Root Cause

In \card.ts\, \enderRoomIcon\ is called with \	his._roomEntity\ (the raw entity from \getRoomEntity\), while the \ctions\ object (which merges \config.actions\) is created **after** and only used by the info section and \ull_card_actions\ overlay.

The hidden \.box\ div in \oom-state-icon.ts\ uses \	his.entity\ for click handling, which has the default navigation path (e.g., \alcony\ without \#\ prefix).

### Fix

Move the \ctions\ object creation before \enderRoomIcon\ and pass it instead of \	his._roomEntity\. This ensures the room icon (including the hidden \.box\ when \hide_room_icon\ is enabled) uses the merged \config.actions\ consistently with the info section and overlay.

### Before
\\\	ypescript
const roomEntity = renderRoomIcon(this._hass, this._roomEntity, ...);
// ...
const actions = { ...this._roomEntity, config: { ...this._roomEntity.config, ...this._config.actions } };
\\\

### After
\\\	ypescript
const actions = { ...this._roomEntity, config: { ...this._roomEntity.config, ...this._config.actions } };
const roomEntity = renderRoomIcon(this._hass, actions, ...);
\\\

This fixes navigation for users who configure \ctions.tap_action.navigation_path\ with hash-based paths (e.g., \#balcony\) while using \hide_room_icon\.